### PR TITLE
add Symbol to possible Literal types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ deps/src/
 .DS_Store
 .vscode
 .ipynb_checkpoints
+
+Manifest.toml

--- a/src/DiagrammaticPrograms.jl
+++ b/src/DiagrammaticPrograms.jl
@@ -1324,7 +1324,7 @@ end
 # Julia expression utilities
 ############################
 
-const Literal = Union{Number,Char,String,QuoteNode}
+const Literal = Union{Number,Char,String,QuoteNode,Symbol}
 
 get_literal(value::Literal) = value
 get_literal(node::QuoteNode) = node.value::Symbol


### PR DESCRIPTION
This will allow one to use `@acset_colim` with ACSets with `Symbol` attributes, which is a common attribute type.