### PR TITLE
Drop pin of Julia version in CI

### DIFF
--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -41,8 +41,6 @@ jobs:
     uses: AlgebraicJulia/.github/.github/workflows/julia_ci.yml@main
     secrets: inherit
     with:
-      version: "1.10.0-beta2"
-      test_versions: "['1.10.0-beta2']"
       docs: false
   CompatHelper:
     if: github.event_name == 'schedule'


### PR DESCRIPTION
The pinning to Julia v1.0 beta in the CI is now out of date since Julia v1.10 has been released for some time.