### PR TITLE
Fix promotion of a gluing query with a conjunctive query

### DIFF
--- a/src/DiagrammaticPrograms.jl
+++ b/src/DiagrammaticPrograms.jl
@@ -945,6 +945,8 @@ promote_query_rule(::Type{<:GlueQuery{C}}, ::Type{<:Ob}) where {Ob,C<:FinCat{Ob}
   GlueQuery{C}
 promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:Ob}) where {Ob,C<:FinCat{Ob}} =
   GlucQuery{C}
+promote_query_rule(::Type{<:GlueQuery{C}}, ::Type{<:ConjQuery{C}}) where C =
+  GlucQuery{C}
 promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:ConjQuery{C}}) where C =
   GlucQuery{C}
 promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:GlueQuery{C}}) where C =
@@ -968,7 +970,7 @@ function convert_query(::C, ::Type{<:GlucQuery{C}}, d::ConjQuery{C}) where C
   s = FreeCategory
   p = Presentation(s)
   add_generator!(p,Ob(s,Symbol("anon_ob")))
-  munit(Diagram{id}, TypeCat(ConjQuery{C}, Any), d;shape=FinCat(p))
+  munit(Diagram{id}, TypeCat(ConjQuery{C}, Any), d; shape=FinCat(p))
 end
 function convert_query(cat::C, ::Type{<:GlucQuery{C}}, d::GlueQuery{C}) where C
   J = shape(d)
@@ -979,7 +981,7 @@ function convert_query(cat::C, ::Type{<:GlucQuery{C}}, d::GlueQuery{C}) where C
     munit(Diagram{op}, cat, hom_map(d, h),
           dom_shape=new_ob[dom(J,h)], codom_shape=new_ob[codom(J,h)])
   end
-  Diagram{id}(FinDomFunctor(new_ob, new_hom, J))
+  Diagram{id}(FinDomFunctor(new_ob, new_hom, J, TypeCat(ConjQuery{C}, Any)))
 end
 function convert_query(cat::C, ::Type{<:GlucQuery{C}}, x::Ob) where
     {Ob, C<:FinCat{Ob}}

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -318,9 +318,9 @@ const GlueSchemaMigration{D<:FinCat,C<:FinCat} =
 const GlucSchemaMigration{D<:FinCat,C<:FinCat} =
   ContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:GlucQuery{C}}}}
 
-
-  # Contravariant migration
+# Contravariant migration
 #########################
+
 function migrate(X::FinDomFunctor,M::ComplexDeltaMigration)
     F = functor(M)
     tgt_schema = dom(F)
@@ -360,12 +360,12 @@ function get_src_schema(F::Functor{<:Cat,<:TypeCat{<:Diagram}})
     get_src_schema(diagram(ob_map(F,obs[1])))
 end
 get_src_schema(F::Functor{<:Cat,<:FinCat}) = codom(F)
-#what the hell happened to the indentation
 
 # Conjunctive migration
 #----------------------
+
 function migrate(X::FinDomFunctor, M::ConjSchemaMigration;
-  return_limits::Bool=false, tabular::Bool=false)
+                 return_limits::Bool=false, tabular::Bool=false)
   F = functor(M)
   tgt_schema = dom(F)
   homs = hom_generators(get_src_schema(F))
@@ -413,7 +413,8 @@ function migrate(X::FinDomFunctor, M::ConjSchemaMigration;
     # Hand the Julia function form of the not-yet-defined components to compose
     universal(compose(Ff, X, f_params), limits[c], limits[d])
   end
-  Y = FinDomFunctor(mapvals(ob, limits), funcs, tgt_schema)
+  cod = isempty(limits) ? TypeCat(FinSet{Int}, FinDomFunction{Int}) : nothing
+  Y = FinDomFunctor(mapvals(ob, limits), funcs, tgt_schema, cod)
   return_limits ? (Y, limits) : Y
 end
 

--- a/test/Migrations.jl
+++ b/test/Migrations.jl
@@ -216,6 +216,13 @@ h′ = @acset Graph begin
 end
 @test h == h′
 
+# Discrete graph on one vertex.
+g = @migrate Graph set begin
+  V => @unit
+  E => @empty
+end
+@test g == Graph(1)
+
 # Migrations with Code
 ######################
 


### PR DESCRIPTION
There were actually several bugs here:

- A missing case in `promote_query_rule`, a bug that goes back to my original code
- Several places where type information was lost due to (what else?) maps over empty vectors