### PR TITLE
Cm/buildkite

### DIFF
--- a/.buildkite/jobscript.sh
+++ b/.buildkite/jobscript.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+module load julia
+
+echo "Running Tests..."
+julia --project -e 'using Pkg; Pkg.status(); Pkg.test()'
+
+echo "Building Documentation..."
+julia -t 16 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,20 @@
+env:
+  JULIA_VERSION: "1.10.2"
+
+steps:
+
+  - label: ":hammer: Build Project"
+    command: 
+      - "module load julia"
+      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
+         
+  - wait 
+
+  - label: ":scroll: Build docs and run tests"
+    command:
+      - "srun --cpus-per-task=16 --mem=8G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"
+    env:
+      JULIA_PROJECT: "docs/"
+
+  - wait
+

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,24 @@
 env:
   JULIA_VERSION: "1.10.2"
+  GATAS_HOME: "~/.gatas/buildkite/agents/$BUILDKITE_AGENT_NAME"
 
 steps:
 
   - label: ":hammer: Build Project"
-    command: 
+    env:
+      JULIA_DEPOT_PATH: "$GATAS_HOME"
+    commands: 
       - "module load julia"
       - "julia --project=docs --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
          
   - wait 
 
-  - label: ":scroll: Build docs and run tests"
-    command:
-      - "srun --cpus-per-task=16 --mem=8G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"
+  - labels: ":scroll: Build docs and run tests"
     env:
+      JULIA_DEPOT_PATH: "$GATAS_HOME/$BUILDKITE_AGENT_NAME"
       JULIA_PROJECT: "docs/"
+    command:
+      - "srun --cpus-per-task=16 --mem=64G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
          
   - wait 
 
-  - labels: ":scroll: Build docs and run tests"
+  - label: ":scroll: Build docs and run tests"
     env:
       JULIA_DEPOT_PATH: "$GATAS_HOME/$BUILDKITE_AGENT_NAME"
       JULIA_PROJECT: "docs/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
 
   - label: ":scroll: Build docs and run tests"
     env:
-      JULIA_DEPOT_PATH: "$GATAS_HOME/$BUILDKITE_AGENT_NAME"
+      JULIA_DEPOT_PATH: "$GATAS_HOME"
       JULIA_PROJECT: "docs/"
     command:
       - "srun --cpus-per-task=16 --mem=64G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,7 +42,7 @@ makedocs(
   pages=Any[
     "DataMigrations.jl"=>"index.md",
     "Examples"=>Any[
-      "generated/literate_example.md",
+      "generated/migrations_intro.md",
     ],
     "Library Reference"=>"api.md",
   ]


### PR DESCRIPTION
This PR

- adds a `.buildkite` folder with the necessary files
- modifies the `pipeline.yml` by
    - having `srun` call for more memory (64G)
    - setting the julia depot to the directory each agent creates via an [agent hook](https://buildkite.com/docs/agent/v3/hooks)
- fixes `make.jl` so the pages/Examples section is pointing to the correct generated literate file
