### PR TITLE
Add submodules to docs build

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,5 @@
 # Library Reference
 
 ```@autodocs
-Modules = [DataMigrations]
+Modules = [DataMigrations, DataMigrations.Migrations, DataMigrations.DiagrammaticPrograms]
 ```


### PR DESCRIPTION
You have to manually list submodules to get them to show up in the auto docs.