### PR TITLE
Fixed autodocs

### DIFF
--- a/.buildkite/build_docs.sh
+++ b/.buildkite/build_docs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Building documentation..."
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.status(); Pkg.instantiate(); include("docs/make.jl")'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,24 +1,7 @@
-env:
-  JULIA_VERSION: "1.10.2"
-  GATAS_HOME: "~/.gatas/buildkite/agents/$BUILDKITE_AGENT_NAME"
-
 steps:
 
-  - label: ":hammer: Build Project"
-    env:
-      JULIA_DEPOT_PATH: "$GATAS_HOME"
-    commands: 
-      - "module load julia"
-      - "julia --project=docs --color=yes -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.precompile()'"
-         
-  - wait 
-
-  - label: ":scroll: Build docs and run tests"
-    env:
-      JULIA_DEPOT_PATH: "$GATAS_HOME"
-      JULIA_PROJECT: "docs/"
-    command:
-      - "srun --cpus-per-task=16 --mem=64G --time=1:00:00 --output=.buildkite/build_%j.log --unbuffered .buildkite/jobscript.sh"
+  - label: ":arrow_down: Load AlgebraicJulia pipeline"
+    command: |
+      curl -s https://raw.githubusercontent.com/AlgebraicJulia/.github/main/buildkite/pipeline.yml | buildkite-agent pipeline upload
 
   - wait
-

--- a/.buildkite/run_tests.sh
+++ b/.buildkite/run_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+pwd; hostname; date
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 VERSION"
+    echo "Example: $0 1.10.0"
+    exit 1
+fi
+
+VERSION=$1
+
+module load julia/$VERSION
+
+echo "Running tests..."
+julia --project -e "using Pkg; Pkg.status(); Pkg.test()"

--- a/.github/workflows/julia_ci.yml
+++ b/.github/workflows/julia_ci.yml
@@ -40,8 +40,6 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.action == 'test')
     uses: AlgebraicJulia/.github/.github/workflows/julia_ci.yml@main
     secrets: inherit
-    with:
-      docs: false
   CompatHelper:
     if: github.event_name == 'schedule'
     uses: AlgebraicJulia/.github/.github/workflows/julia_compat.yml@main

--- a/docs/literate/migrations_intro.jl
+++ b/docs/literate/migrations_intro.jl
@@ -1,4 +1,6 @@
-# DataMigrations.jl includes facilities for categorical data migrations.
+# # Introduction to Data Migrations
+
+# DataMigrations.jl includes facilities for categorical data migrations. 
 # We'll start by example, working with some graph schemas from Catlab.
 
 using Catlab, DataMigrations

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,3 +3,12 @@
 ```@autodocs
 Modules = [DataMigrations]
 ```
+
+```@autodocs
+Modules = [DataMigrations.Migrations]
+```
+
+```@autodocs
+Modules = [DataMigrations.DiagrammaticPrograms]
+Private = false
+```

--- a/src/DataMigrations.jl
+++ b/src/DataMigrations.jl
@@ -13,9 +13,11 @@ module DataMigrations
 
 using Reexport
 export func
+
 include("Migrations.jl")
 include("DiagrammaticPrograms.jl")
 
 @reexport using .Migrations
 @reexport using .DiagrammaticPrograms
+
 end

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -94,7 +94,7 @@ consisting of `shape_map`, `diagram_map`, and `precomposed_diagram`
 is whiskered with `X` (except where it's undefined), 
 and then the functions in `params` are used to fill in the gaps.
 
-See also [`QueryDiagram`](@ref), [`param_compose`](@ref)
+See also [`QueryDiagram`](@ref)
 """
 struct QueryDiagramHom{T,C<:Cat,F<:FinFunctor,Φ<:FinTransformation,D<:Functor{<:FinCat,C},Params<:AbstractDict}<:DiagramHom{T,C}
   shape_map::F
@@ -143,28 +143,6 @@ DiagramHom{T}(f::QueryDiagramHom) where T =
   QueryDiagramHom{T}(f.shape_map, f.diagram_map, f.precomposed_diagram,get_params(f))
 
 
-#Note there's currently no composition of QueryDiagramHoms.
-
-#This and some others can probably be dispatched to just querydiagramhoms?
-"""
-    compose(f::DiagramHom,F::Functor,params[;kw...])
-
-Whisker a partially-defined `DiagramHom` with a 
-`Functor`, using the dictionary `params` to fill in any gaps. 
-
-While [`QueryDiagramHom`](@ref)s have internal `params` for a similar
-purpose, it is sometimes necessary to borrow `params` from
-a [`QueryDiagram`](@ref) or [`DataMigration`](@ref) containing `f`, which
-is the functionality enabled here.
-
-See also: `param_compose`
-"""
-function compose(f::DiagramHom{T}, F::Functor, params;kw...) where T
-  whiskered = param_compose(diagram_map(f),F,params)
-  DiagramHom{T}(shape_map(f), whiskered,
-                compose(f.precomposed_diagram, F; kw...))
-end
-
 """
     param_compose(α,H,params)
 
@@ -193,6 +171,27 @@ function param_compose(α::FinTransformation, H::Functor,params)
   end
   FinTransformation(new_components,compose(F, H), compose(G, H))
 end
+
+#Note there's currently no composition of QueryDiagramHoms.
+
+#This and some others can probably be dispatched to just querydiagramhoms?
+"""
+    compose(f::DiagramHom,F::Functor,params[;kw...])
+
+Whisker a partially-defined `DiagramHom` with a 
+`Functor`, using the dictionary `params` to fill in any gaps. 
+
+While [`QueryDiagramHom`](@ref)s have internal `params` for a similar
+purpose, it is sometimes necessary to borrow `params` from
+a [`QueryDiagram`](@ref) containing `f`, which
+is the functionality enabled here.
+"""
+function compose(f::DiagramHom{T}, F::Functor, params;kw...) where T
+  whiskered = param_compose(diagram_map(f),F,params)
+  DiagramHom{T}(shape_map(f), whiskered,
+                compose(f.precomposed_diagram, F; kw...))
+end
+
 
 """
     compose(d::QueryDiagram,F::Functor[;kw...])


### PR DESCRIPTION
This PR fixes the @autodocs for DataMigrations and updates the buildkite pipeline script to refer to the organization's pipeline.
![image](https://github.com/user-attachments/assets/b108eb59-0608-4ba2-aab5-0c21157452d8)
