### PR TITLE
Remove Documenter from Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.1"
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GATlab = "f0ffcf3b-d13a-433e-917c-cc44ccf5ead2"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
@@ -16,7 +15,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ACSets = "0.2.20"
-Documenter = "1"
 GATlab = "0.0.7,0.1"
 Catlab = "0.16.12"
 Literate = "2"


### PR DESCRIPTION
I saw that Documenter is getting pulled in downstream, but it looks like we can remove it from this package.