### PR TITLE
Catlab 0.17 compatibility for data migrations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ACSets = "0.2.20"
-GATlab = "0.0.7,0.1"
-Catlab = "0.16.12"
+GATlab = "0.0.7, 0.1, 0.2"
+Catlab = "0.16.12, 0.17"
 Literate = "2"
 MLStyle = "0.4"
 Reexport = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ACSets = "0.2.20"
-GATlab = "0.0.7, 0.1, 0.2"
-Catlab = "0.16.12, 0.17"
+GATlab = "0.2"
+Catlab = "0.17"
 Literate = "2"
 MLStyle = "0.4"
 Reexport = "1"

--- a/src/DiagrammaticPrograms.jl
+++ b/src/DiagrammaticPrograms.jl
@@ -14,13 +14,21 @@ using MLStyle: @match
 
 using Catlab
 using Catlab.Theories: munit, FreeSchema, FreePointedSetSchema, ThPointedSetSchema, FreeCategory, FreePointedSetCategory, zeromap, Ob, Hom, dom, codom, HomExpr
-using Catlab.CategoricalAlgebra.FinCats: FinCat, mapvals, make_map, FinCatPresentation
+import Catlab.CategoricalAlgebra.Cats.FinCats: FinCat, FinCatPresentation
+using Catlab.CategoricalAlgebra.Cats.FinFunctors: mapvals, make_map
 using ..Migrations
-using ..Migrations: ConjQuery, GlueQuery, GlucQuery
+using ..Migrations: ConjQuery, GlueQuery, GlucQuery, QueryDiagram, QueryDiagramHom,
+  make_diagram, make_diagram_unit, make_diagram_hom_unit
 using GATlab
 import GATlab: Presentation
 import GATlab.Models.Presentations:construct_generator!,construct_generators!
 const DiagramGraph = NamedGraph{Symbol,Symbol}
+typed_typecat(ObT, HomT) =
+  Category(TypeCat{ObT,HomT}(Dispatch(Catlab.CategoricalAlgebra.Cats.Categories.ThCategory, [ObT, HomT])))
+ob_generator_name(C, x) = nameof(x)
+hom_generator_name(C, f) = nameof(f)
+ob_generator(C, x::Symbol) = only(filter(y -> nameof(y) == x, collect(ob_generators(C))))
+hom_generator(C, f::Symbol) = only(filter(g -> nameof(g) == f, collect(hom_generators(C))))
 
 # Abstract syntax
 #################
@@ -248,7 +256,7 @@ function parse_functor(C::FinCat, D::FinCat, ast::AST.Mapping;
                        check_equations::Bool=false)
   ob_map, hom_map = make_ob_hom_maps(C, ast)
   F = FinFunctor(mapvals(x -> parse_ob(D, x), ob_map),
-                 mapvals(f -> parse_hom(D, f), hom_map), C, D)
+                 mapvals(f -> parse_hom(D, f), hom_map), C, D; homtype=:hom)
   failures = functoriality_failures(F, check_equations=check_equations)
   if !all(isempty,failures)
     doms, cods = failures[1], failures[2]
@@ -295,7 +303,7 @@ end
 
 """ Parse expression for object in a category.
 """
-function parse_ob(C::FinCat{Ob,Hom}, expr::AST.ObExpr) where {Ob,Hom}
+function parse_ob(C::FinCat, expr::AST.ObExpr)
   @match expr begin
     AST.ObGenerator(name) => @match name begin
       x::Symbol => ob_generator(C, x)
@@ -308,11 +316,11 @@ end
 
 """ Parse expression for morphism in a category.
 """
-function parse_hom(C::FinCat{Ob,Hom}, expr::AST.HomExpr) where {Ob,Hom}
+function parse_hom(C::FinCat, expr::AST.HomExpr)
   @match expr begin
     AST.HomGenerator(name) => @match name begin
       f::Symbol => hom_generator(C, f)
-      Expr(:curly, _...) => parse_gat_expr(C, name)::Hom
+      Expr(:curly, _...) => parse_gat_expr(C, name)
       _ => error("Invalid morphism generator $name")
     end
     AST.Compose(args) => mapreduce(
@@ -326,7 +334,7 @@ end
 """ Parse GAT expression based on curly braces, rather than parentheses.
 """
 function parse_gat_expr(C::FinCat, root_expr)
-  pres = presentation(C)
+  pres = presentation(C.val)
   function parse(expr)
     @match expr begin
       Expr(:curly, head::Symbol, args...) =>
@@ -372,8 +380,10 @@ function Diagrams.Diagram(d::DiagramData{T}, codom) where T
   #sure the shape is based on non-pointed stuff
   simple = isempty(d.params)
   new_shape = change_shape(simple,d.shape)
-  F = FinDomFunctor(d.ob_map, d.hom_map, new_shape, codom)
-  simple ? SimpleDiagram{T}(F) : QueryDiagram{T}(F, d.params)
+  F = codom isa FinCat ?
+    FinDomFunctor(d.ob_map, d.hom_map, new_shape, codom; homtype=:hom) :
+    FinDomFunctor(d.ob_map, d.hom_map, new_shape, codom)
+  simple ? make_diagram(T, F) : QueryDiagram{T}(F, d.params)
 end
 function change_shape(simple::Bool,old_shape::FinCatPresentation)
   old_pres = presentation(old_shape)
@@ -648,14 +658,10 @@ Uses the output of `yoneda`:
 end
 """
 macro acset_colim(yon, body)
-  body = quote
-    I => @join $body
-  end
-  ast = AST.Diagram(parse_diagram_ast(body, mod=__module__))
   quote
-    p = Presentation(acset_schema(last(first($(esc(yon)).ob_map))))
-    tmp = parse_migration(p, $ast)
-    ob_map(colimit_representables(tmp, $(esc(yon))), :I)
+    Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda.colimit_representables(
+      $(Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda.parse_diagram_data(body, __module__)),
+      $(esc(yon)))[2]
   end
 end
 
@@ -733,8 +739,8 @@ function parse_query(C::FinCat, expr::AST.ObExpr)
       parse_query_diagram(C, stmts, type=op)
     AST.Colimit(stmts) || AST.Coproduct(stmts) =>
       parse_query_diagram(C, stmts, type=id)
-    AST.Terminal() => DiagramData{op}([], [], FinCat(Presentation(presentation(C).syntax)))
-    AST.Initial() => DiagramData{id}([], [], FinCat(Presentation(presentation(C).syntax)))
+    AST.Terminal() => DiagramData{op}([], [], FinCat(Presentation(presentation(C.val).syntax)))
+    AST.Initial() => DiagramData{id}([], [], FinCat(Presentation(presentation(C.val).syntax)))
   end
 end
 
@@ -751,8 +757,7 @@ end
 Get the map in the source schema corresponding to a map
 of two singleton diagrams.
 """
-function parse_query_hom(C::FinCat{Ob}, expr::AST.HomExpr,
-                         ::Ob, ::Union{Ob,Nothing}) where Ob
+function parse_query_hom(C::FinCat, expr::AST.HomExpr, x, y)
   parse_hom(C, expr)
 end
 
@@ -761,9 +766,19 @@ end
 Create DiagramHomData for the case of a map between two
   conjunctive diagrams.
 """
-function parse_query_hom(C::FinCat{Ob}, ast::AST.Mapping,
-                         d::Union{Ob,DiagramData{op}}, d′::DiagramData{op}) where Ob
-  ob_rhs, hom_rhs = make_ob_hom_maps(shape(d′), ast, allow_missing=d isa Ob)
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d, d′::DiagramData{op})
+  ob_rhs, hom_rhs = make_ob_hom_maps(shape(d′), ast, allow_missing=!(d isa DiagramData))
+  f_ob = mapvals(ob_rhs, keys=true) do j′, rhs
+    parse_diagram_ob_rhs(C, rhs, ob_map(d′, j′), d)
+  end
+  f_hom = mapvals(rhs -> parse_hom(d, rhs), hom_rhs)
+  DiagramHomData{op}(f_ob, f_hom)
+end
+
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d::DiagramData{op}, d′::DiagramData{op})
+  ob_rhs, hom_rhs = make_ob_hom_maps(shape(d′), ast, allow_missing=false)
   f_ob = mapvals(ob_rhs, keys=true) do j′, rhs
     parse_diagram_ob_rhs(C, rhs, ob_map(d′, j′), d)
   end
@@ -774,8 +789,8 @@ end
 Create DiagramHomData for the case of a map from a single
   object to a conjunctive diagram.
 """
-function parse_query_hom(C::FinCat{Ob}, ast::AST.Mapping,
-                         d::DiagramData{op}, c′::Ob) where Ob
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d::DiagramData{op}, c′)
   assign = only(ast.assignments)
   DiagramHomData{op}(Dict(c′=> parse_diagram_ob_rhs(C, assign.rhs, c′, d)), Dict())
 end
@@ -783,8 +798,7 @@ end
 # Gluing fragment.
 #The reason for the possible argument variance mismatch seems to be that 
 #you might still need to promote later on.
-function parse_query_hom(C::FinCat{Ob}, ast::AST.Mapping, d::DiagramData{id},
-                         d′::Union{Ob,DiagramData{op},DiagramData{id}}) where Ob
+function parse_query_hom(C::FinCat, ast::AST.Mapping, d::DiagramData{id}, d′)
   ob_rhs, hom_rhs = make_ob_hom_maps(shape(d), ast,
                                      allow_missing=!(d′ isa DiagramData{id}))
   homnames = Symbol[nameof(x) for x in hom_generators(C)]
@@ -800,11 +814,52 @@ function parse_query_hom(C::FinCat{Ob}, ast::AST.Mapping, d::DiagramData{id},
   f_hom = mapvals(rhs -> parse_hom(d′, rhs), hom_rhs)
   DiagramHomData{id}(f_ob, f_hom,params)
 end
-function parse_query_hom(C::FinCat{Obj}, ast::AST.Mapping,
-                         c::Union{Obj,DiagramData{op}}, d′::DiagramData{id}) where Obj
+
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d::DiagramData{id}, d′::DiagramData{op})
+  ob_rhs, hom_rhs = make_ob_hom_maps(shape(d), ast, allow_missing=true)
+  homnames = Symbol[nameof(x) for x in hom_generators(C)]
+  params = Dict{Symbol,Any}()
+  f_ob = mapvals(ob_rhs, keys=true) do j, rhs
+    if rhs isa AST.MixedOb
+      aux_func = make_func(rhs.jcode.mod, rhs.jcode.code, homnames)
+      params[nameof(j)] = aux_func
+      rhs = rhs.oexp
+    end
+    parse_diagram_ob_rhs(C, rhs, ob_map(d, j), d′)
+  end
+  f_hom = mapvals(rhs -> parse_hom(d′, rhs), hom_rhs)
+  DiagramHomData{id}(f_ob, f_hom, params)
+end
+
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d::DiagramData{id}, d′::DiagramData{id})
+  ob_rhs, hom_rhs = make_ob_hom_maps(shape(d), ast, allow_missing=false)
+  homnames = Symbol[nameof(x) for x in hom_generators(C)]
+  params = Dict{Symbol,Any}()
+  f_ob = mapvals(ob_rhs, keys=true) do j, rhs
+    if rhs isa AST.MixedOb
+      aux_func = make_func(rhs.jcode.mod, rhs.jcode.code, homnames)
+      params[nameof(j)] = aux_func
+      rhs = rhs.oexp
+    end
+    parse_diagram_ob_rhs(C, rhs, ob_map(d, j), d′)
+  end
+  f_hom = mapvals(rhs -> parse_hom(d′, rhs), hom_rhs)
+  DiagramHomData{id}(f_ob, f_hom, params)
+end
+
+function parse_query_hom(C::FinCat, ast::AST.Mapping, c, d′::DiagramData{id})
   assign = only(ast.assignments)
-  cob = c isa Obj ? c : Ob(FreeCategory,:anon_ob)
+  cob = c isa DiagramData{op} ? Ob(FreeCategory,:anon_ob) : c
   DiagramHomData{id}(Dict(cob => parse_diagram_ob_rhs(C, assign.rhs, c, d′)), Dict())
+end
+
+function parse_query_hom(C::FinCat, ast::AST.Mapping,
+                         d::DiagramData{op}, d′::DiagramData{id})
+  assign = only(ast.assignments)
+  DiagramHomData{id}(Dict(Ob(FreeCategory, :anon_ob) =>
+    parse_diagram_ob_rhs(C, assign.rhs, d, d′)), Dict())
 end
 
 #expr will be an ObExpr
@@ -833,31 +888,91 @@ parse_hom(C, ::Missing) = missing
 # Query construction
 #-------------------
 
-function make_query(C::FinCat{Ob}, data::DiagramData{T}) where {T, Ob}
+function make_query(C::FinCat, data::DiagramData{T}) where T
   F_ob, F_hom, J = data.ob_map, data.hom_map, shape(data)
   F_hom = mapvals((h,f) -> isnothing(f) ? zeromap(F_ob[dom(J,h)],F_ob[codom(J,h)]) : f,F_hom;keys=true)
   F_ob = mapvals(x -> make_query(C, x), F_ob)
-  query_type = mapreduce(typeof, promote_query_type, values(F_ob), init=Ob)
+  query_type = isempty(F_ob) ? Union{} : mapreduce(typeof, promote_query_type, values(F_ob))
+  if query_type == Any && any(x -> x isa Diagram, values(F_ob))
+    query_type = Diagram
+  end
   @assert query_type != Any
-  F_ob = mapvals(x -> convert_query(C, query_type, x), F_ob)
+  lift_to_gluc = query_type <: DiagramId &&
+    any(needs_gluc_lift, values(F_ob))
+  F_ob = mapvals(F_ob) do x
+    if lift_to_gluc
+      convert_query_gluc(C, x)
+    else
+      convert_query(C, query_type, x)
+    end
+  end
   F_hom = mapvals(F_hom;keys=true) do h,f
     d,c = F_ob[dom(J,h)],F_ob[codom(J,h)]
     make_query_hom(C,f,d,c)
   end
-  if query_type <: Ob
+  if isempty(F_ob) || !(query_type <: Diagram)
     Diagram(DiagramData{T}(F_ob, F_hom, J, data.params), C)
   else
     # XXX: Why is the element type of `F_ob` sometimes too loose?
-    D = TypeCat(typeintersect(query_type, eltype(values(F_ob))),
-                eltype(values(F_hom)))
+    D = typed_typecat(typeintersect(query_type, eltype(values(F_ob))),
+                      eltype(values(F_hom)))
     Diagram(DiagramData{T}(F_ob, F_hom, J,data.params), D)
   end
 end
 
-make_query(C::FinCat{Ob}, x::Ob) where Ob = x
+make_query(C::FinCat, x) = x
 
-function make_query_hom(C::FinCat, f::DiagramHomData{op},
-                        d::Diagram{op}, d′::Diagram{op})
+needs_gluc_lift(::Any) = false
+needs_gluc_lift(d::DiagramOp) = true
+needs_gluc_lift(d::DiagramId) = !(codom(diagram(d)) isa FinCat)
+query_ob_component(D::Diagram, j) = let x = ob_map(D, j)
+  x isa DiagramOp ? Pair(j, DiagramHom(id[FinCatC()](dom(x)), id[Cat2()](diagram(x)), x)) :
+  x isa Diagram ? Pair(j, id(x)) : j
+end
+
+function convert_query_gluc(cat::FinCat, d::DiagramId)
+  codom(diagram(d)) isa FinCat || return d
+  J = shape(d)
+  F_ob = map(ob_generators(J)) do j
+    j => convert_query(cat, DiagramOp, ob_map(d, j))
+  end |> Dict
+  F_hom = map(hom_generators(J)) do h
+    s, t = F_ob[dom(J, h)], F_ob[codom(J, h)]
+    h => make_query_hom(cat, hom_map(diagram(d), h), s, t)
+  end |> Dict
+  Diagram(DiagramData{id}(F_ob, F_hom, J), typed_typecat(ConjQuery, Any))
+end
+convert_query_gluc(cat::FinCat, d::DiagramOp) = convert_query(cat, DiagramId, d)
+convert_query_gluc(cat::FinCat, x) =
+  convert_query(cat, DiagramId, convert_query(cat, DiagramOp, x))
+
+_cell1(pair::Union{Pair,Tuple{Any,Any}}) = first(pair)
+_cell1(x) = x
+_cell2(::Diagram, pair::Union{Pair,Tuple{Any,Any}}) = last(pair)
+_cell2(D::Diagram, x) = id(codom(D), ob_map(D, x))
+
+function _make_query_hom_op(ob_maps, hom_map, d::Diagram, d′::Diagram)
+  if d isa DiagramOp && d′ isa DiagramOp
+    return DiagramHom(ob_maps, hom_map, d, d′)
+  end
+  f = FinDomFunctor(mapvals(_cell1, ob_maps), hom_map, dom(d′), dom(d); homtype=:hom)
+  ϕ = Transformation(mapvals(x -> _cell2(d, x), ob_maps),
+                     compose[CatC()](f, diagram(d)), diagram(d′); check=false)
+  DiagramHom(f, ϕ, d)
+end
+
+function _make_query_hom_id(params, ob_maps, hom_map, d::Diagram, d′::Diagram)
+  if d isa DiagramId && d′ isa DiagramId
+    return QueryDiagramHom{id}(params, ob_maps, hom_map, d, d′)
+  end
+  f = FinFunctor(mapvals(_cell1, ob_maps), hom_map, dom(d), dom(d′); homtype=:hom)
+  ϕ = Transformation(mapvals(x -> _cell2(d′, x), ob_maps),
+                     diagram(d), compose[CatC()](f, diagram(d′)); check=false)
+  QueryDiagramHom{id}(DiagramHom(f, ϕ, d′), params)
+end
+
+function _make_query_hom_data(C::FinCat, f::DiagramHomData{op},
+                              d::Diagram, d′::Diagram)
   f_ob = mapvals(f.ob_map, keys=true) do j′, x
     x = @match x begin
       ::Missing => only_ob(shape(d))
@@ -866,15 +981,35 @@ function make_query_hom(C::FinCat, f::DiagramHomData{op},
     end
     @match x begin
       (j, g) => Pair(j, make_query_hom(C, g, ob_map(d, j), ob_map(d′, j′)))
-      j => j
+      j => query_ob_component(d, j)
     end
   end
   f_hom = mapvals(h -> ismissing(h) ? only_hom(shape(d)) : h, f.hom_map)
-  DiagramHom{op}(f_ob, f_hom, d, d′)
+  _make_query_hom_op(f_ob, f_hom, d, d′)
 end
 
-function make_query_hom(C::FinCat, f::DiagramHomData{id},
-                        d::Diagram{id}, d′::Diagram{id})
+function make_query_hom(C::FinCat, f::DiagramHomData{op},
+                        d::DiagramOp, d′::DiagramOp)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{op},
+                        d::QueryDiagram, d′::Diagram)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{op},
+                        d::Diagram, d′::QueryDiagram)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{op},
+                        d::QueryDiagram, d′::QueryDiagram)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function _make_query_hom_data(C::FinCat, f::DiagramHomData{id},
+                              d::Diagram, d′::Diagram)
   f_ob = mapvals(f.ob_map, keys=true) do j, x
     x = @match x begin
       ::Missing => only_ob(shape(d′))
@@ -887,47 +1022,74 @@ function make_query_hom(C::FinCat, f::DiagramHomData{id},
         g = isnothing(g) ? zeromap(s,t) : g
         Pair(j′, make_query_hom(C, g, s,t))
       end
-      j′ => j′
+      j′ => query_ob_component(d′, j′)
     end
   end
   f_hom = mapvals(h -> ismissing(h) ? only_hom(shape(d′)) : h, f.hom_map)
-  QueryDiagramHom{id}(f.params,f_ob, f_hom, d, d′)
+  _make_query_hom_id(f.params, f_ob, f_hom, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{id},
+                        d::DiagramId, d′::DiagramId)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{id},
+                        d::QueryDiagram, d′::Diagram)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{id},
+                        d::Diagram, d′::QueryDiagram)
+  _make_query_hom_data(C, f, d, d′)
+end
+
+function make_query_hom(C::FinCat, f::DiagramHomData{id},
+                        d::QueryDiagram, d′::QueryDiagram)
+  _make_query_hom_data(C, f, d, d′)
 end
 
 """If d,d' are singleton diagrams and f hasn't yet been specified, make a DiagramHom with the right
 domain, codomain, and shape_map but the natural transformation component left as GATExpr{:zeromap} for now.
 Otherwise just wrap f up as a DiagramHom between singletons.
 """
-function make_query_hom(::C, f::Hom, d::Diagram{T,C}, d′::Diagram{T,C}) where
-    {T, Ob, Hom, C<:FinCat{Ob,Hom}}
-  munit(DiagramHom{T}, codom(diagram(d)), f,
-  dom_shape=shape(d), codom_shape=shape(d′))
-end
-function make_query_hom(::C, f::HomExpr{:zeromap}, d::Diagram{T,C}, d′::Diagram{T,C}) where {T,C<:FinCat}
+singleton_query_hom(f, d::DiagramId, d′::DiagramId) = begin
   j′ = only(ob_generators(shape(d′)))
   j = only(ob_generators(shape(d)))
-  DiagramHom{T}(Dict(j=> Pair(j′,f)),d,d′)
+  DiagramHom(Dict(j => Pair(j′, f)), d, d′)
 end
 
-function make_query_hom(::C, f::Hom, d::Diagram{op,C}, d′::Diagram{op,C}) where
-    {Ob, Hom, C<:FinCat{Ob,Hom}}
-  munit(DiagramHom{op}, codom(diagram(d)), f,
-  dom_shape=shape(d), codom_shape=shape(d′))
+function make_query_hom(::C, f, d::DiagramId, d′::DiagramId) where C
+  if f isa DiagramHomData{op}
+    f′ = make_query_hom(C, f, only(collect_ob(d)), only(collect_ob(d′)))
+    singleton_query_hom(f′, d, d′)
+  else
+    singleton_query_hom(f, d, d′)
+  end
 end
 
-function make_query_hom(::C, f::HomExpr{:zeromap}, d::Diagram{op,C}, d′::Diagram{op,C}) where C<:FinCat
+function make_query_hom(C::FinCat, f, d::DiagramId, d′::DiagramId)
+  if f isa DiagramHomData{op}
+    f′ = make_query_hom(C, f, only(collect_ob(d)), only(collect_ob(d′)))
+    singleton_query_hom(f′, d, d′)
+  else
+    singleton_query_hom(f, d, d′)
+  end
+end
+
+function make_query_hom(::C, f, d::DiagramOp, d′::DiagramOp) where C
   j′ = only(ob_generators(shape(d′)))
   j = only(ob_generators(shape(d)))
-  DiagramHom{op}(Dict(j′=> Pair(j,f)),d,d′)
-end
-function make_query_hom(c::C, f::Union{Hom,DiagramHomData{op}},
-                        d::Diagram{id}, d′::Diagram{id}) where
-    {Ob, Hom, C<:FinCat{Ob,Hom}}
-  f′ = make_query_hom(c, f, only(collect_ob(d)), only(collect_ob(d′)))
-  munit(DiagramHom{id}, codom(diagram(d)), f′, dom_shape=shape(d), codom_shape=shape(d′))
+  DiagramHom(Dict(j′ => Pair(j, f)), d, d′)
 end
 
-make_query_hom(C::FinCat{Ob,Hom}, f::Hom, x::Ob, y::Ob) where {Ob,Hom} = f
+function make_query_hom(::FinCat, f, d::DiagramOp, d′::DiagramOp)
+  j′ = only(ob_generators(shape(d′)))
+  j = only(ob_generators(shape(d)))
+  DiagramHom(Dict(j′ => Pair(j, f)), d, d′)
+end
+
+make_query_hom(C::FinCat, f, x, y) = f
 
 only_ob(C::FinCat) = only(ob_generators(C))
 only_hom(C::FinCat) = (@assert is_discrete(C); id(C, only_ob(C)))
@@ -939,18 +1101,10 @@ only_hom(C::FinCat) = (@assert is_discrete(C); id(C, only_ob(C)))
 # https://docs.julialang.org/en/v1/manual/conversion-and-promotion/
 
 promote_query_rule(::Type, ::Type) = Union{}
-promote_query_rule(::Type{<:ConjQuery{C}}, ::Type{<:Ob}) where {Ob,C<:FinCat{Ob}} =
-  ConjQuery{C}
-promote_query_rule(::Type{<:GlueQuery{C}}, ::Type{<:Ob}) where {Ob,C<:FinCat{Ob}} =
-  GlueQuery{C}
-promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:Ob}) where {Ob,C<:FinCat{Ob}} =
-  GlucQuery{C}
-promote_query_rule(::Type{<:GlueQuery{C}}, ::Type{<:ConjQuery{C}}) where C =
-  GlucQuery{C}
-promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:ConjQuery{C}}) where C =
-  GlucQuery{C}
-promote_query_rule(::Type{<:GlucQuery{C}}, ::Type{<:GlueQuery{C}}) where C =
-  GlucQuery{C}
+promote_query_rule(::Type{<:DiagramOp}, ::Type) = DiagramOp
+promote_query_rule(::Type{<:DiagramId}, ::Type) = DiagramId
+promote_query_rule(::Type{<:DiagramId}, ::Type{<:DiagramOp}) = DiagramId
+promote_query_rule(::Type{<:DiagramOp}, ::Type{<:DiagramId}) = DiagramId
 
 promote_query_type(T, S) = promote_query_result(
   T, S, Union{promote_query_rule(T,S), promote_query_rule(S,T)})
@@ -958,34 +1112,35 @@ promote_query_result(T, S, ::Type{Union{}}) = typejoin(T, S)
 promote_query_result(T, S, U) = U
 
 convert_query(::FinCat, ::Type{T}, x::S) where {T, S<:T} = x
+convert_query(::FinCat, ::Type{<:Diagram}, d::Diagram) = d
+convert_query(::FinCat, ::Type{<:DiagramOp}, d::DiagramOp) = d
+convert_query(::FinCat, ::Type{<:DiagramId}, d::DiagramId) = d
+convert_query(cat::FinCat, ::Type{<:Diagram}, x) = convert_query(cat, DiagramOp, x)
 
-function convert_query(cat::C, ::Type{<:Diagram{T,C}}, x::Obj) where
-  {T, Obj, C<:FinCat{Obj}}
-  s = presentation(cat).syntax 
+function convert_query(cat::FinCat, ::Type{<:DiagramOp}, x)
+  s = presentation(cat.val).syntax
   p = Presentation(s)
-  add_generator!(p,Ob(s,nameof(x)))
-  munit(Diagram{T}, cat, x, shape=FinCat(p))
+  add_generator!(p, Ob(s, nameof(x)))
+  J = FinCat(p)
+  j = only(ob_generators(J))
+  make_diagram(op, FinDomFunctor(Dict(j => x), Dict(), J, cat; homtype=:hom))
 end
-function convert_query(::C, ::Type{<:GlucQuery{C}}, d::ConjQuery{C}) where C
-  s = FreeCategory
+
+function convert_query(cat::FinCat, ::Type{<:DiagramId}, x)
+  s = presentation(cat.val).syntax
   p = Presentation(s)
-  add_generator!(p,Ob(s,Symbol("anon_ob")))
-  munit(Diagram{id}, TypeCat(ConjQuery{C}, Any), d; shape=FinCat(p))
+  add_generator!(p, Ob(s, nameof(x)))
+  J = FinCat(p)
+  j = only(ob_generators(J))
+  make_diagram(id, FinFunctor(Dict(j => x), Dict(), J, cat; homtype=:hom))
 end
-function convert_query(cat::C, ::Type{<:GlucQuery{C}}, d::GlueQuery{C}) where C
-  J = shape(d)
-  new_ob = make_map(ob_generators(J)) do j
-    convert_query(cat, ConjQuery{C}, ob_map(d, j))
-  end
-  new_hom = make_map(hom_generators(J)) do h
-    munit(Diagram{op}, cat, hom_map(d, h),
-          dom_shape=new_ob[dom(J,h)], codom_shape=new_ob[codom(J,h)])
-  end
-  Diagram{id}(FinDomFunctor(new_ob, new_hom, J, TypeCat(ConjQuery{C}, Any)))
-end
-function convert_query(cat::C, ::Type{<:GlucQuery{C}}, x::Ob) where
-    {Ob, C<:FinCat{Ob}}
-  convert_query(cat, GlucQuery{C}, convert_query(cat, ConjQuery{C}, x))
+function convert_query(::FinCat, ::Type{<:DiagramId}, d::DiagramOp)
+  s = presentation(shape(d).val).syntax
+  p = Presentation(s)
+  add_generator!(p, Ob(s, Symbol("anon_ob")))
+  J = FinCat(p)
+  j = only(ob_generators(J))
+  make_diagram(id, FinDomFunctor(Dict(j => d), Dict(), J, typed_typecat(ConjQuery, Any); homtype=:hom))
 end
 
 # Julia expression to AST

--- a/src/Migrations.jl
+++ b/src/Migrations.jl
@@ -8,17 +8,114 @@ export migrate,migrate!,colimit_representables, QueryDiagram, DataMigration, col
 using ACSets
 using ACSets.DenseACSets: constructor, datatypes
 using Catlab
+using GATlab: getvalue
 using Catlab.Theories: ob, hom, dom, codom, attr, AttrTypeExpr, ⋅
 import Catlab.Theories: compose
-import Catlab: ob_map, hom_map, functor
-using Catlab.CategoricalAlgebra.FinCats: make_map, mapvals, presentation_key, FinCatPresentation, FinDomFunctorMap
-import Catlab.CategoricalAlgebra.FinCats: force
+import Catlab: id, ob_map, hom_map, functor, gen_map
+using Catlab.BasicSets: TaggedElem, TypeSet
+using Catlab.CategoricalAlgebra.Cats.FinCats: FinCatPresentation
+using Catlab.CategoricalAlgebra.Cats.FinCats.FinCatPres: presentation_key
+using Catlab.CategoricalAlgebra.Cats.FinFunctors: make_map, mapvals, FinDomFunctorMap
+using Catlab.CategoricalAlgebra.SetCats.SkelFinSetCat.Limits: indexed_universal, FinSetIndexedLimit
+using Catlab.CategoricalAlgebra.SetCats.SkelFinSetCat: SkelFinSet
+using Catlab.CategoricalAlgebra.SetCats.SkelFinSetCat.Colimits: composite_universal
+using Catlab.BasicSets.FinSetInts: FinSetInt
+import Catlab: force
 using Catlab.CategoricalAlgebra.Chase: collage, crel_type, pres_to_eds, add_srctgt, chase
-using Catlab.CategoricalAlgebra.FinSets: VarSet
-using Catlab.CategoricalAlgebra.Sets: SetFunctionCallable
 import Catlab.CategoricalAlgebra.FunctorialDataMigrations: migrate, migrate!, AbstractDataMigration, ContravariantMigration, DeltaSchemaMigration
 import Catlab.CategoricalAlgebra.Diagrams: DiagramHom
+using GATlab: Dispatch
 using MLStyle: @match
+ob_generator_name(C, x) = nameof(x)
+hom_generator_name(C, f) = nameof(f)
+_lookup_generator(xs, name::Symbol) = let matches = [x for x in collect(xs) if nameof(x) == name]
+  length(matches) == 1 || error("No unique generator named $name")
+  only(matches)
+end
+_resolve_ob_key(F, x::Symbol) = _lookup_generator(ob_generators(dom(F)), x)
+_resolve_ob_key(F, x) = applicable(ob_map, F, x) ? x :
+                        _lookup_generator(ob_generators(dom(F)), nameof(x))
+_resolve_hom_key(F, x::Symbol) = _lookup_generator(hom_generators(dom(F)), x)
+_resolve_hom_key(F, x) = applicable(gen_map, F, x) ? x :
+                         _lookup_generator(hom_generators(dom(F)), nameof(x))
+Catlab.ob_map(F::FunctorFinDom, x::Symbol) = ob_map(F, _resolve_ob_key(F, x))
+Catlab.hom_map(F::FunctorFinDom, x::Symbol) = gen_map(F, _resolve_hom_key(F, x))
+Catlab.hom_map(F::FunctorFinDom, x::GATlab.Models.SymbolicModels.GATExpr{:generator}) =
+  gen_map(F, _resolve_hom_key(F, x))
+typed_typecat(ObT, HomT) =
+  Category(TypeCat{ObT,HomT}(Dispatch(Catlab.CategoricalAlgebra.Cats.Categories.ThCategory, [ObT, HomT])))
+unwrap_tagged(x) = x isa TaggedElem ? getvalue(x) : x
+
+function _diagram_freegraph_data(F::FunctorFinDom)
+  C = dom(F)
+  D = Category(codom(F))
+  obs_gen = collect(ob_generators(C))
+  obs = [ob_map(F, x) for x in obs_gen]
+  obix = Dict(x => i for (i, x) in enumerate(obs_gen))
+  homs = map(collect(hom_generators(C))) do h
+    fh = hom_map(F, h)
+    s, t = dom(C, h), codom(C, h)
+    fs, ft = ob_map(F, s), ob_map(F, t)
+    fh_dom, fh_cod = dom(D, fh), codom(D, fh)
+    if fh_dom == fs && fh_cod == ft
+      (fh, obix[s], obix[t])
+    elseif fh_dom == ft && fh_cod == fs
+      (fh, obix[t], obix[s])
+    else
+      error("Could not align mapped hom $h with diagram objects")
+    end
+  end
+  (obs_gen=obs_gen, obs=obs, obix=obix, homs=homs, cat=D)
+end
+function _diagram_freegraph(F::FunctorFinDom)
+  data = _diagram_freegraph_data(F)
+  FreeGraph(data.obs, data.homs)
+end
+_diagram_freegraph(d::Diagram) = _diagram_freegraph(diagram(d))
+_diagram_freegraph_data(d::Diagram) = _diagram_freegraph_data(diagram(d))
+
+_query_path_symbols(f) = head(f) == :id ? Symbol[] :
+                         head(f) == :compose ? error("Composite parameterized query paths are not yet supported here") :
+                         [nameof(f)]
+
+function _query_diagram_data(q)
+  Fj = diagram(q)
+  Cj = dom(Fj)
+  data = Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda.DiagramData()
+  fixed = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in pairs(q.params))
+  fixed_paths = Dict{Symbol,Pair{Symbol,Vector{Symbol}}}()
+  for h in hom_generators(Cj)
+    tgt = nameof(codom(Cj, h))
+    if haskey(fixed, tgt)
+      fixed_paths[tgt] = nameof(dom(Cj, h)) => _query_path_symbols(hom_map(Fj, h))
+    end
+  end
+  for x in ob_generators(Cj)
+    xname = nameof(x)
+    if !(haskey(fixed, xname) && haskey(fixed_paths, xname))
+      push!(data.reprs[nameof(ob_map(Fj, x))], xname)
+    end
+  end
+  for h in hom_generators(Cj)
+    tgt = nameof(codom(Cj, h))
+    if !(haskey(fixed, tgt) && haskey(fixed_paths, tgt))
+      push!(data.eqs,
+            (nameof(dom(Cj, h)) => _query_path_symbols(hom_map(Fj, h))) =>
+            (tgt => Symbol[]))
+    end
+  end
+  for (k, v) in pairs(fixed)
+    data.vals[get(fixed_paths, k, k => Symbol[])] = v
+  end
+  data
+end
+
+_query_apex(q, y::FunctorFinDom) =
+  Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda.colimit_representables(
+    _query_diagram_data(q), y)[2]
+
+id(d::Catlab.CategoricalAlgebra.Cats.Diagrams.DiagramOp) =
+  id[Catlab.CategoricalAlgebra.Cats.Diagrams.DiagramOpCat()](d)
 
 #Extra data structures for fancy diagrams and diagram homs,
 #and their interaction with ordinary functors and nats.
@@ -46,9 +143,21 @@ the inner `diagram`. If the keys of `params` are constants
 then ``Y`` will receive constant attributes at the 
 corresponding values.
 """
-struct QueryDiagram{T,C<:Cat,D<:Functor{<:FinCat,C},
-                    Params<:AbstractDict} <: Diagram{T,C,D}
-  diagram::D
+diagram_kind(::typeof(id)) = :id
+diagram_kind(::typeof(op)) = :op
+diagram_kind(::Any) = :id
+
+diagram_type(::typeof(id)) = DiagramId
+diagram_type(::typeof(op)) = DiagramOp
+diagram_type(::Any) = DiagramId
+
+make_diagram(T, F::FunctorFinDom) = diagram_type(T)(F)
+make_diagram_unit(T, C, x; shape=nothing) = munit(diagram_type(T), C, x; shape)
+make_diagram_hom_unit(T, C, f; dom_shape=nothing, codom_shape=nothing) =
+  munit(DiagramHom, C, f; dom_shape, codom_shape, cat=diagram_kind(T))
+
+struct QueryDiagram{T,F<:FunctorFinDom,Params<:AbstractDict} <: Diagram
+  fun::F
   params::Params
 end
 """
@@ -65,19 +174,23 @@ the type of `F`. The type `C` of the codomain `F`
 will in practice be a subtype of `FinCat` or of 
 `Diagram``{T}`. 
 """
-QueryDiagram{T}(F::D, params::P) where {T,C<:Cat,D<:Functor{<:FinCat,C},P} =
-  QueryDiagram{T,C,D,P}(F, params)
+QueryDiagram{T}(fun::F, params::P) where {T,F<:FunctorFinDom,P<:AbstractDict} =
+  QueryDiagram{T,F,P}(fun, params)
 """
     force(d::QueryDiagram,[args...])
 
 Force-evaluate the `d.diagram` for a `QueryDiagram` `d`.
-  
+
 The result is a `SimpleDiagram`, and in particular
 the inner call to `force` attempts to use `d.params`
 to produce a fully-defined `FinDomFunctor`.
 """
 force(d::QueryDiagram{T},args...) where T =
-  SimpleDiagram{T}(force(diagram(d),d.params,args...))
+  make_diagram(T, force(diagram(d), d.params, args...))
+
+force(d::DiagramId, args...) = DiagramId(force(diagram(d), args...))
+force(d::DiagramOp, args...) = DiagramOp(force(diagram(d), args...))
+force(d::DiagramCo, args...) = DiagramCo(force(diagram(d), args...))
 
 """
 A `DiagramHom` that may be partially-defined, to be evaluated later
@@ -96,10 +209,8 @@ and then the functions in `params` are used to fill in the gaps.
 
 See also [`QueryDiagram`](@ref)
 """
-struct QueryDiagramHom{T,C<:Cat,F<:FinFunctor,Φ<:FinTransformation,D<:Functor{<:FinCat,C},Params<:AbstractDict}<:DiagramHom{T,C}
-  shape_map::F
-  diagram_map::Φ
-  precomposed_diagram::D
+struct QueryDiagramHom{T,H<:DiagramHom,Params<:AbstractDict}
+  hom::H
   params::Params
 end
 
@@ -109,9 +220,16 @@ end
 Construct a `QueryDiagramHom` of variance `T` and fields the given arguments,
 with further type parameters inferred.
 """
-QueryDiagramHom{T}(shape_map::F, diagram_map::Φ, precomposed_diagram::D,params::Params) where
-{T,C,F<:FinFunctor,Φ<:FinTransformation,D<:Functor{<:FinCat,C},Params<:AbstractDict} =
-QueryDiagramHom{T,C,F,Φ,D,Params}(shape_map, diagram_map, precomposed_diagram,params) 
+QueryDiagramHom{T}(shape_map, diagram_map, precomposed_diagram::D, params::Params) where
+{T,D<:Diagram,Params<:AbstractDict} =
+  QueryDiagramHom{T}(DiagramHom(shape_map, diagram_map, precomposed_diagram), params)
+
+QueryDiagramHom{T}(dh::H, params::Params) where {T,H<:DiagramHom,Params<:AbstractDict} =
+  QueryDiagramHom{T,H,Params}(dh, params)
+
+_trivial_query_ob(q::QueryDiagram) = _trivial_query_ob(only(collect_ob(diagram(q))))
+_trivial_query_ob(q::Diagram) = _trivial_query_ob(only(collect_ob(q)))
+_trivial_query_ob(x) = x
 
 
 #XX: Maybe this isn't needed?
@@ -124,6 +242,16 @@ Otherwise return an empty `Dict`.
 get_params(f::QueryDiagramHom) = f.params
 get_params(f::DiagramHom) = Dict()
 
+Catlab.shape_map(f::QueryDiagramHom) = Catlab.shape_map(f.hom)
+Catlab.diagram_map(f::QueryDiagramHom) = Catlab.diagram_map(f.hom)
+precomposed_diagram(f::QueryDiagramHom) = f.hom.precomposed_diagram
+Catlab.Theories.dom(f::QueryDiagramHom) = Catlab.Theories.dom(f.hom)
+Catlab.Theories.codom(f::QueryDiagramHom) = Catlab.Theories.codom(f.hom)
+Catlab.ob_map(f::QueryDiagramHom, x) = ob_map(f.hom, x)
+Catlab.hom_map(f::QueryDiagramHom, x) = hom_map(f.hom, x)
+Catlab.collect_ob(f::QueryDiagramHom) = collect_ob(f.hom)
+Catlab.collect_hom(f::QueryDiagramHom) = collect_hom(f.hom)
+
 """
     QueryDiagramHom{T}(params,args...)
 
@@ -134,13 +262,10 @@ There are many methods of `DiagramHom` allowing various calling conventions,
 and this allows `QueryDiagramHom` to steal them all reasonably efficiently.
 """
 function QueryDiagramHom{T}(params::Params,args...) where {T,Params<:AbstractDict}
-  dh = DiagramHom{T}(args...)
+  dh = DiagramHom(args...)
   QueryDiagramHom{T}(dh,params)
 end
-QueryDiagramHom{T}(dh::DiagramHom{T},params::Params) where {T,Params<:AbstractDict} =
-  QueryDiagramHom{T}(dh.shape_map,dh.diagram_map,dh.precomposed_diagram,params)
-DiagramHom{T}(f::QueryDiagramHom) where T =
-  QueryDiagramHom{T}(f.shape_map, f.diagram_map, f.precomposed_diagram,get_params(f))
+DiagramHom(f::QueryDiagramHom) = f.hom
 
 
 """
@@ -152,27 +277,93 @@ given any needed parameters `params` specifying the functions in
 
 Currently assumes the result will be a totally defined transformation.
 """
-function param_compose(α::FinTransformation, H::Functor,params)
+function param_compose(α::FinTransformation, H::FunctorFinDom, params)
   F, G = dom(α), codom(α)
+  FH = compose_partial(F, H)
+  GH = compose_partial(G, H)
+  # Wrap raw model objects (e.g. FinSetInt) from ob_map into AbsSet
+  _wrap(o) = o isa AbsSet ? o :
+             o isa ACSets.ACSet ? o :
+             o isa TaggedElem ? o :
+             FinSet(length(o))
+  _id_component(o) = o isa TaggedElem ? o :
+                     o isa FinSet ? FinFunction(o) :
+                     o isa AbsSet ? SetFunction(o) :
+                     id(o)
+  _param_haskey(ps, k) = haskey(ps, k) || haskey(ps, nameof(k))
+  _param_get(ps, k) = haskey(ps, k) ? ps[k] : ps[nameof(k)]
   new_components = mapvals(pairs(components(α));keys=true) do i,f
-    compindex = ob(dom(F),i)
+    compindex = i  # generator is already an Ob in Catlab 0.17
     #allow non-strictness because of possible pointedness
-    s, t = ob_map(compose(F,H),compindex), 
-    ob_map(compose(G,H),compindex)
+    s, t = _wrap(ob_map(FH, compindex)),
+    _wrap(ob_map(GH, compindex))
     if head(f) == :zeromap
-      func = params[i]
-      FinDomFunction(func,s,t)
+      func = _param_get(params, i)
+      if t isa TaggedElem
+        vals_raw = [func(x) for x in collect(s)]
+        ElT = isempty(vals_raw) ? Any : typejoin(typeof.(vals_raw)...)
+        vals = ElT[v for v in vals_raw]
+        TaggedElem(FinDomFunction(vals, SetOb(TypeSet(ElT))), GATlab.gettag(t))
+      else
+        FinDomFunction(func, s, t)
+      end
     #may need to population params with identities
     else
-      Hf = hom_map(H,f)
-      func = haskey(params,i) ? SetFunction(params[i],codom(Hf),t) : id(t)
-      Hf⋅func
+      Hf = head(f) == :id ? _id_component(s) : hom_map(H, presentation_key(f))
+      if _param_haskey(params, i)
+        if Hf isa TaggedElem
+          Hf′ = getvalue(Hf)
+          func = SetFunction(_param_get(params, i), codom(Hf′), codom(Hf′))
+          TaggedElem(Catlab.BasicSets.postcompose(Hf′, func), GATlab.gettag(Hf))
+        elseif t isa TaggedElem
+          vals_raw = [_param_get(params, i)(Hf(x)) for x in collect(dom(Hf))]
+          ElT = isempty(vals_raw) ? Any : typejoin(typeof.(vals_raw)...)
+          vals = ElT[v for v in vals_raw]
+          TaggedElem(FinDomFunction(vals, SetOb(TypeSet(ElT))), GATlab.gettag(t))
+        else
+          func = SetFunction(_param_get(params, i), codom(Hf), t)
+          compose[SetC()](Hf, func)
+        end
+      else
+        Hf  # composing with identity is a no-op
+      end
     end
   end
-  FinTransformation(new_components,compose(F, H), compose(G, H))
+  # check=false: AttrType components may be TaggedElem placeholders that
+  # are not valid morphisms in the collage category (Catlab 0.17 limitation).
+  # They are handled specially by _attr_universal downstream.
+  FinTransformationMap(new_components, FH, GH; check=false)
 end
 
 #Note there's currently no composition of QueryDiagramHoms.
+
+function _compose_nested_diagram_functor(D::FunctorFinDom, F::FunctorFinDom, homfuns)
+  C = dom(D)
+  obs = make_map(ob_generators(C)) do x
+    force(compose(ob_map(D, x), F))
+  end
+  _param_haskey(ps, k) = haskey(ps, k) || haskey(ps, nameof(k))
+  _param_get(ps, k) = haskey(ps, k) ? ps[k] : ps[nameof(k)]
+  homs = make_map(hom_generators(C)) do h
+    fh = hom_map(D, h)
+    if fh isa QueryDiagramHom
+      ps = isempty(get_params(fh)) ? Dict{Any,Any}() : mapvals(x -> x(homfuns...), get_params(fh))
+      compose(fh, F, ps)
+    elseif fh isa DiagramHom
+      compose(fh, F, Dict{Any,Any}())
+    else
+       Hf = head(fh) == :id ? id(only(collect_ob(obs[dom(C, h)]))) :
+            hom_map(F, presentation_key(fh))
+      s = obs[dom(C, h)]
+      t = obs[codom(C, h)]
+      DataMigrations.DiagrammaticPrograms.make_query_hom(get_src_schema(F), Hf, s, t)
+    end
+  end
+  ObT = isempty(obs) ? Any : typejoin(typeof.(values(obs))...)
+  HomT = isempty(homs) ? Any : typejoin(typeof.(values(homs))...)
+  cod = typed_typecat(ObT, HomT)
+  FinDomFunctor(obs, homs, C, cod)
+end
 
 #This and some others can probably be dispatched to just querydiagramhoms?
 """
@@ -186,10 +377,52 @@ purpose, it is sometimes necessary to borrow `params` from
 a [`QueryDiagram`](@ref) containing `f`, which
 is the functionality enabled here.
 """
-function compose(f::DiagramHom{T}, F::Functor, params;kw...) where T
-  whiskered = param_compose(diagram_map(f),F,params)
-  DiagramHom{T}(shape_map(f), whiskered,
-                compose(f.precomposed_diagram, F; kw...))
+function compose(f::Union{DiagramHom,QueryDiagramHom}, F::FunctorFinDom, params; kw...)
+  base = f isa QueryDiagramHom ? DiagramHom(f) : f
+  α = diagram_map(base)
+  Fα, Gα = dom(α), codom(α)
+  J = dom(Fα)
+  if !isempty(ob_generators(J)) && any(i -> ob_map(Fα, i) isa Diagram, ob_generators(J))
+    src_pres = presentation(getvalue(dom(F)))
+    homs = hom_generators(get_src_schema(F))
+    homfuns = map(x -> unwrap_tagged(hom_map(F, src_pres[presentation_key(x)])), homs)
+    FH = _compose_nested_diagram_functor(Fα, F, homfuns)
+    GH = _compose_nested_diagram_functor(Gα, F, homfuns)
+    new_components = mapvals(pairs(components(α)); keys=true) do i, comp
+      if comp isa QueryDiagramHom
+        ps = isempty(get_params(comp)) ? Dict{Any,Any}() : mapvals(x -> x(homfuns...), get_params(comp))
+        compose(comp, F, ps)
+      elseif comp isa DiagramHom
+        compose(comp, F, Dict{Any,Any}())
+      else
+        Hcomp = head(comp) == :id ? id(only(collect_ob(ob_map(FH, i)))) :
+                hom_map(F, src_pres[presentation_key(comp)])
+        DataMigrations.DiagrammaticPrograms.make_query_hom(get_src_schema(F), Hcomp,
+                                                          ob_map(FH, i), ob_map(GH, i))
+      end
+    end
+    whiskered = Transformation(FinTransformationMap(new_components, FH, GH; check=false))
+    return DiagramHom(shape_map(base), whiskered, compose(base.precomposed_diagram, F; kw...))
+  end
+  whiskered = Transformation(param_compose(diagram_map(base), F, params))
+  DiagramHom(shape_map(base), whiskered,
+             compose(base.precomposed_diagram, F; kw...))
+end
+
+compose(f::DiagramHom, F::FunctorFinDom; kw...) =
+  compose(f, F, Dict{Any,Any}(); kw...)
+
+function _diagram_colimit_universal(f::DiagramHom, dom_colim, codom_colim)
+  J = dom(shape_map(f))
+  AC = Category(ACSetCategory(apex(codom_colim)))
+  obs = Dict(j => i for (i, j) in enumerate(collect(ob_generators(codom(shape_map(f))))))
+  cocone = Multicospan(apex(codom_colim), map(collect(ob_generators(J))) do j
+    j′, g = ob_map(f, j)
+    ιⱼ′ = legs(codom_colim)[obs[j′]]
+    compose(AC, g, ιⱼ′)
+  end)
+  Catlab.CategoricalAlgebra.Pointwise.LimitsColimits.Colimits.pointwise_universal(
+    ACSetCategory(apex(dom_colim)), dom_colim, cocone)
 end
 
 
@@ -205,25 +438,58 @@ still to be filled in.
 
 See also: `force`, `QueryDiagram`
 """
-function compose(d::QueryDiagram{T},F::Functor; kw...) where T
+function compose(d::QueryDiagram{T},F::FunctorFinDom; kw...) where T
   D = diagram(d)
-  partial = compose(D,F) #cannot be evaluated on the keys of params yet
+  partial = compose_partial(D, F) # cannot be evaluated on the keys of params yet
   #Get the FinDomFunctions in the range of F that must be plugged into
   #the Functions in params
   params = d.params
   mors = hom_generators(codom(D))
-  morfuns = map(x->hom_map(F,x),mors)
-  params_new = Dict{keytype(params),FinDomFunction}()
+  src_pres = presentation(getvalue(dom(F)))
+  morfuns = map(x -> unwrap_tagged(hom_map(F, src_pres[presentation_key(x)])), mors)
+  params_new = Dict{keytype(params),Any}()
+  partial_pres = presentation(getvalue(dom(partial)))
   for (n,f) in params #Calculate the intended value of the composition on n
-    domain = ob_map(partial,dom(hom(dom(partial),n)))
-    codomain = ob_map(partial,codom(hom(dom(partial),n)))
-    params_new[n] =
-      FinDomFunction(f(morfuns...),domain,codomain)
+    h = partial_pres[presentation_key(n)]
+    domain = ob_map(partial, dom(h))
+    codomain = ob_map(partial, codom(h))
+    func = f(morfuns...)
+    if codomain isa TaggedElem
+      vals_raw = [func(x) for x in collect(domain)]
+      ElT = isempty(vals_raw) ? Any : typejoin(typeof.(vals_raw)...)
+      vals = ElT[v for v in vals_raw]
+      params_new[n] = TaggedElem(FinDomFunction(vals, SetOb(TypeSet(ElT))), nameof(codom(h)))
+    else
+      domain = domain isa FinSet ? domain : FinSet(length(domain))
+      params_new[n] = FinDomFunction(func, domain, codomain)
+    end
   end
   #This will now contain a composite functor which can't 
   #necessarily be hom-mapped; ready to be forced.
   QueryDiagram{T}(partial,params_new)
 end
+
+function compose_partial(D::FunctorFinDom, F::FunctorFinDom)
+  C = dom(D)
+  obs = make_map(ob_generators(C)) do x
+    fx = ob_map(D, x)
+    ob_map(F, _resolve_ob_key(F, fx))
+  end
+  homs = make_map(hom_generators(C)) do h
+    fx = hom_map(D, h)
+    head(fx) == :zeromap ? fx :
+    head(fx) == :id ? id(codom(F), obs[dom(C, h)]) :
+    gen_map(F, _resolve_hom_key(F, fx))
+  end
+  ObT = isempty(obs) ? Any : typejoin(typeof.(values(obs))...)
+  HomT = isempty(homs) ? Any : typejoin(typeof.(values(homs))...)
+  cod = typed_typecat(ObT, HomT)
+  FinDomFunctor(obs, homs, C, cod)
+end
+
+compose(d::DiagramId, F::FunctorFinDom; kw...) = DiagramId(compose_partial(diagram(d), F))
+compose(d::DiagramOp, F::FunctorFinDom; kw...) = DiagramOp(compose_partial(diagram(d), F))
+compose(d::DiagramCo, F::FunctorFinDom; kw...) = DiagramCo(compose_partial(diagram(d), F))
 
 #Does the type guarantee definitely hold for empty collections?
 """
@@ -237,13 +503,17 @@ If `Obtype` and `Homtype` are specified, then the
 returned functor is guaranteed to have exactly those
 value types in its `ob_map` and `hom_map`.
 """
-function force(F::FinDomFunctor, params,Obtype::Type=Any, Homtype::Type=Any)
+function force(F::FinDomFunctor, params::AbstractDict, Obtype::Type=Any, Homtype::Type=Any)
   C = dom(F)
-  FinDomFunctor(
-    make_map(x -> ob_map(F, x), ob_generators(C), Obtype),
-    make_map(hom_generators(C), Homtype) do f 
-     haskey(params,hom_generator_name(C,f)) ? params[hom_generator_name(C,f)] : hom_map(F,f) end , 
-    C)
+  obs = make_map(x -> ob_map(F, x), ob_generators(C), Obtype)
+  homs = make_map(hom_generators(C), Homtype) do f
+    haskey(params, hom_generator_name(C, f)) ? params[hom_generator_name(C, f)] : hom_map(F, f)
+  end
+  cod = typed_typecat(
+    isempty(obs) ? Any : typejoin(typeof.(values(obs))...),
+    isempty(homs) ? Any : typejoin(typeof.(values(homs))...)
+  )
+  FinDomFunctor(obs, homs, C, cod)
 end
 
 ###New data types for complex queries
@@ -259,7 +529,7 @@ be computed in ``Set``.
 
 See also: `GlueQuery`, `GlucQuery`
 """
-const ConjQuery{C<:FinCat} = Diagram{op,C}
+const ConjQuery = DiagramOp
 
 """ Gluing or agglomerative query over schema ``C``.
 
@@ -269,7 +539,7 @@ coproduct and the query is called "linear" or "disjunctive".
 
 See also: `ConjQuery`, `GlucQuery`
 """
-const GlueQuery{C<:FinCat} = Diagram{id,C}
+const GlueQuery = DiagramId
 
 """ "Gluc query" (gluing of conjunctive queries) over schema ``C``.
 
@@ -280,7 +550,7 @@ a "duc query" (disjoint union of conjunctive queries).
 
 See also: `GlueQuery`, `GlucQuery`
 """
-const GlucQuery{C<:FinCat} = Diagram{id,<:TypeCat{<:Diagram{op,C}}}
+const GlucQuery = DiagramId
 
 #The same, except for the supertype and the variance parameter T, as a QueryDiagram.
 #In this case, the codomain of F is probably a category of queri
@@ -292,30 +562,34 @@ we have access to `X`'s attributes and homs. The dictionary of parameters contai
 functions acting on ``X``'s attributes using Julia functions defined on 
 these attribute types.
 """
-struct DataMigration{F<:FinDomFunctor,Params<:AbstractDict} <: ContravariantMigration{F}
+struct DataMigration{F<:FunctorFinDom,Params<:AbstractDict} <: ContravariantMigration
   functor::F
   params::Params
 end
-DataMigration(F::FinDomFunctor) = DataMigration(F,Dict{Any,Union{}}())
-DataMigration(h::SimpleDiagram) = DataMigration(diagram(h))
+DataMigration(F::FunctorFinDom) = DataMigration(F,Dict{Any,Union{}}())
+DataMigration(h::Diagram) = DataMigration(diagram(h))
 DataMigration(h::QueryDiagram) = DataMigration(diagram(h),h.params)
 
-const ComplexDeltaMigration{F<:FinFunctor,Params<:AbstractDict} = DataMigration{F,Params}
+function migrate(X::ACSet, M::DataMigration; kw...)
+  migrate(Catlab.CategoricalAlgebra.Cats.FinFunctors.FinDomFunctor(X; check=false), M; kw...)
+end
+function migrate(::Type{T}, X::ACSet, M::DataMigration; kw...) where T <: ACSet
+  T(migrate(X, M; kw...))
+end
+
+const ComplexDeltaMigration = DataMigration
 
 """ Schema-level functor defining a contravariant data migration using conjunctive queries.
 """
-const ConjSchemaMigration{D<:FinCat,C<:FinCat} =
-  ContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:ConjQuery{C}}}}
+const ConjSchemaMigration = ContravariantMigration
 
 """ Schema-level functor defining a contravariant data migration using gluing queries.
 """
-const GlueSchemaMigration{D<:FinCat,C<:FinCat} =
-  ContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:GlueQuery{C}}}}
+const GlueSchemaMigration = ContravariantMigration
 
 """ Schema-level functor defining a contravariant data migration using gluc queries.
 """
-const GlucSchemaMigration{D<:FinCat,C<:FinCat} =
-  ContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:GlucQuery{C}}}}
+const GlucSchemaMigration = ContravariantMigration
 
 # Contravariant migration
 #########################
@@ -323,22 +597,49 @@ const GlucSchemaMigration{D<:FinCat,C<:FinCat} =
 function migrate(X::FinDomFunctor,M::ComplexDeltaMigration)
     F = functor(M)
     tgt_schema = dom(F)
-    src_schema = get_src_schema(F)
+    # Check if this is actually a diagram-valued migration (conj/glue/gluc)
+    gens = collect(ob_generators(tgt_schema))
+    if !isempty(gens)
+      q = ob_map(F, first(gens))
+      if q isa Union{DiagramOp, Catlab.CategoricalAlgebra.Cats.Diagrams.DiagramId, DiagramCo} ||
+         q isa QueryDiagram
+        return _migrate_contravariant(X, M)
+      end
+    end
+    src_schema = dom(X)
+    src_pres = presentation(getvalue(src_schema))
     obs = make_map(ob_generators(tgt_schema)) do c
       Fc = ob_map(F,c)
-      ob_map(X,Fc)
+      ob_map(X, src_pres[presentation_key(Fc)])
     end
     homs = hom_generators(src_schema)
-    homfuns = map(x->hom_map(X,x),homs)
+    homfuns = map(x -> unwrap_tagged(hom_map(X, x)), homs)
     params = M.params
     funcs = make_map(hom_generators(tgt_schema)) do f
       Ff, c, d = hom_map(F, f), dom(tgt_schema, f), codom(tgt_schema, f)
       if head(Ff) == :zeromap
         domain = obs[c]
+        domain = domain isa FinSet ? domain : FinSet(length(domain))
         codomain = obs[d]
-        FinDomFunction(params[nameof(f)](homfuns...),domain,codomain)
+        func = params[nameof(f)](homfuns...)
+        if codomain isa TaggedElem
+          vals_raw = [func(x) for x in collect(domain)]
+          ElT = isempty(vals_raw) ? Any : typejoin(typeof.(vals_raw)...)
+          vals = ElT[v for v in vals_raw]
+          TaggedElem(FinDomFunction(vals, SetOb(TypeSet(ElT))), GATlab.gettag(codomain))
+        else
+          FinDomFunction(func, domain, codomain)
+        end
       else 
-        hom_map(X,Ff)
+        if head(Ff) == :id
+          obj = obs[c]
+          obj isa TaggedElem ? obj :
+          obj isa FinSetInt ? id(Category(SkelFinSet()), obj) :
+          obj isa AbsSet ? id(Category(SetC()), obj) :
+          error("Unsupported identity component for $obj")
+        else
+          hom_map(X, src_pres[presentation_key(Ff)])
+        end
       end
     end
     FinDomFunctor(
@@ -354,47 +655,395 @@ Get the source schema of a data migration functor, recursing in the case
 that the proximate codomain is a diagram category.
 """
 function get_src_schema(F::Functor{<:Cat,<:TypeCat{<:Diagram}})
-  obs = collect(keys(F.ob_map))
+  obs = ob_generators(dom(F))
     length(obs) > 0 || return FinCat(0)
-    get_src_schema(diagram(ob_map(F,obs[1])))
+    get_src_schema(diagram(ob_map(F, first(obs))))
+end
+function get_src_schema(F::Functor{<:Cat,<:Catlab.CategoricalAlgebra.Cats.Diagrams.DiagramCat})
+  obs = ob_generators(dom(F))
+    length(obs) > 0 || return FinCat(0)
+    get_src_schema(diagram(ob_map(F, first(obs))))
 end
 get_src_schema(F::Functor{<:Cat,<:FinCat}) = codom(F)
+function get_src_schema(F::FunctorFinDom)
+  C = codom(F)
+  C = C isa Category ? getvalue(C) : C
+  if C isa TypeCat{<:Diagram} ||
+     C isa Catlab.CategoricalAlgebra.Cats.Diagrams.DiagramCat
+    obs = ob_generators(dom(F))
+    length(obs) > 0 || return FinCat(0)
+    return get_src_schema(diagram(ob_map(F, first(obs))))
+  elseif C isa FinCat
+    return C
+  else
+    error("unsupported data migration codomain $(typeof(C))")
+  end
+end
+
+function free_diagram(F::FunctorFinDom)
+  D_cat = dom(F)
+  # Determine type sets needed by inspecting hom codomains for attr morphisms
+  type_sets = Dict{Int,Any}()
+  gen_to_idx = Dict(g => i for (i, g) in enumerate(ob_generators(D_cat)))
+  _unwrap_h(h) = begin
+    h = h isa TaggedElem ? getvalue(h) : h
+    h isa CopairedFinDomFunction ? get(h) : h
+  end
+  _set_value(x) = x isa SetOb ? getvalue(x) : x
+  function _lift_to_target(h, target)
+    h isa Union{FinFunction,FinDomFunction} || return h
+    target_set = target isa AbsSet ? target : SetOb(target)
+    raw_target = _set_value(target_set)
+    raw_codom = _set_value(codom(h))
+    raw_target isa EitherSet || return h
+    raw_codom == raw_target && return h
+    left_set = _set_value(Catlab.BasicSets.left(raw_target))
+    right_set = _set_value(Catlab.BasicSets.right(raw_target))
+    vals_raw =
+      raw_codom == left_set ? [Left(h(x)) for x in collect(dom(h))] :
+      raw_codom == right_set ? [Right(h(x)) for x in collect(dom(h))] :
+      nothing
+    isnothing(vals_raw) && return h
+    FinDomFunction(vals_raw, dom(h), target_set)
+  end
+
+  # First pass: detect TypeSet codomains from hom_map values
+  for f in hom_generators(D_cat)
+    h_unwrapped = _unwrap_h(hom_map(F, f))
+    if h_unwrapped isa FinDomFunction
+      cd = codom(h_unwrapped)
+      tgt_idx = gen_to_idx[codom(D_cat, f)]
+      cd = cd isa AbsSet ? cd : SetOb(cd)
+      if haskey(type_sets, tgt_idx)
+        cur = type_sets[tgt_idx]
+        cur_val = _set_value(cur)
+        cd_val = _set_value(cd)
+        type_sets[tgt_idx] = cur_val isa EitherSet ? cur :
+                             cd_val isa EitherSet ? cd : cur
+      else
+        type_sets[tgt_idx] = cd
+      end
+    end
+  end
+
+  # Wrap raw model objects (e.g. FinSetInt) to match dom/codom of hom_map values
+  obs = map(ob_generators(D_cat)) do g
+    o = ob_map(F, g)
+    idx = gen_to_idx[g]
+    if haskey(type_sets, idx)
+      type_sets[idx]
+    elseif o isa AbsSet
+      o
+    elseif codom(F) isa FinCat
+      o
+    elseif o isa TaggedElem
+      SetOb(TypeSet{Any}())
+    else
+      FinSet(length(o))
+    end
+  end
+  homs = map(hom_generators(D_cat)) do f
+    h = _unwrap_h(hom_map(F, f))
+    h = _lift_to_target(h, obs[gen_to_idx[codom(D_cat, f)]])
+    (h, gen_to_idx[dom(D_cat, f)], gen_to_idx[codom(D_cat, f)])
+  end
+  g = FreeGraph{Any,Any}()
+  add_vertices!(g, length(obs), ob=collect(obs))
+  !isempty(homs) && add_edges!(g, getindex.(homs, 2), getindex.(homs, 3), hom=first.(homs))
+  FreeDiagram(g)
+end
+
+"""Build a FreeGraph with wrapped FinSet/FinFunction objects for SkelFinSet colimits."""
+function raw_free_graph(F::FunctorFinDom)
+  D_cat = dom(F)
+  gen_to_idx = Dict(g => i for (i, g) in enumerate(ob_generators(D_cat)))
+  obs_vals = map(ob_generators(D_cat)) do g
+    o = ob_map(F, g)
+    if o isa FinSet
+      o
+    elseif o isa FinSetInt
+      FinSet(length(o))
+    elseif o isa TaggedElem
+      FinSet(0)  # placeholder for AttrType
+    else
+      FinSet(length(o))
+    end
+  end
+  hom_vals = map(hom_generators(D_cat)) do f
+    h = hom_map(F, f)
+    h = h isa TaggedElem ? getvalue(h) : h
+    h = h isa CopairedFinDomFunction ? get(h) : h
+    (h, gen_to_idx[dom(D_cat, f)], gen_to_idx[codom(D_cat, f)])
+  end
+  ObT = isempty(obs_vals) ? FinSet : typejoin(typeof.(obs_vals)...)
+  HomT = isempty(hom_vals) ? FinFunction : typejoin(typeof.(first.(hom_vals))...)
+  obs = ObT[o for o in obs_vals]
+  homs = Tuple{HomT,Int,Int}[h for h in hom_vals]
+  g = FreeGraph{ObT,HomT}()
+  add_vertices!(g, length(obs), ob=obs)
+  !isempty(homs) && add_edges!(g, getindex.(homs, 2), getindex.(homs, 3), hom=first.(homs))
+  g
+end
+
+"""Compute limit of a FreeDiagram with legs for ALL original vertices.
+
+BipartiteFreeDiagram limits only return legs for V₁ (source) vertices.
+This helper reconstructs legs for V₂ (target) vertices by composing
+the appropriate V₁ leg with the connecting hom.
+"""
+function full_limit(fd::FreeDiagram)
+  g = getvalue(fd)
+  if nv(g) == 0
+    # Empty diagram: terminal object with no legs
+    term = FinSet(1)
+    cone = Multispan(SetOb(term), Any[])
+    return LimitCone(cone, fd)
+  end
+  bpd = BipartiteFreeDiagram(fd)
+  lim = limit[SetC()](bpd)
+  bpd_legs = legs(lim)
+
+  n_orig = nparts(bpd, :V)
+  full_legs_vec = Vector{Any}(undef, n_orig)
+
+  # V₁ legs → original vertices
+  for (i, ov) in enumerate(bpd[:orig_vert₁])
+    full_legs_vec[ov] = bpd_legs[i]
+  end
+
+  # V₂ legs → compose through any incoming edge
+  for (v2_local, ov) in enumerate(bpd[:orig_vert₂])
+    incoming = incident(bpd, v2_local, :tgt)
+    @assert !isempty(incoming) "V₂ vertex $v2_local must have incoming edges"
+    e = first(incoming)
+    v1_local = src(bpd, e)
+    h = hom(bpd, e)
+    full_legs_vec[ov] = compose[SetC()](bpd_legs[v1_local], h)
+  end
+
+  cone = Multispan(ob(lim), full_legs_vec)
+  LimitCone(cone, fd)
+end
+
+function tabular_limit(lim::AbsLimit; names=nothing)
+  πs = legs(lim)
+  domset = dom(first(πs))
+  rows = collect(domset)
+  colnames = isnothing(names) ? Tuple(Symbol(i) for i in eachindex(πs)) :
+    Tuple(Symbol(name) for name in names)
+  columns = Tuple(map(π -> map(π, rows), πs))
+  table = TabularSet(NamedTuple{colnames}(columns))
+  cone = Multispan(SetOb(table), map(πs, eachindex(πs)) do π, i
+    codset = let c = codom(π)
+      c isa AbsSet ? c : FinSet(length(c))
+    end
+    SetFunction(row -> row[i], SetOb(table), codset)
+  end)
+  LimitCone(cone, diagram(lim))
+end
+
+"""Compute the attribute function for an Attr morphism targeting an AttrType.
+
+For Attr morphisms, the codomain is an AttrType with a trivial (single-object)
+diagram. The attribute function maps each element of the domain Ob-limit to a
+value in the attribute type by composing the domain limit legs with the
+DiagramHom's morphism components.
+"""
+function _attr_universal(f::DiagramHom, dom_lim)
+  # Extract dom shape
+  dom_diag_fun = f.precomposed_diagram.fun
+  dom_cat = dom(dom_diag_fun)
+  dom_gens = collect(ob_generators(dom_cat))
+  obs = Dict(g => i for (i, g) in enumerate(dom_gens))
+
+  # The codomain diagram has a single object (the AttrType)
+  dm = getvalue(f.diagram_map)
+  codom_fun = dm.codom
+  J′ = dom(codom_fun)
+  j′ = only(collect(ob_generators(J′)))
+  j, g = ob_map(f, j′)
+  πⱼ = legs(dom_lim)[obs[j]]
+  # Unwrap TaggedElem (Catlab 0.17 wraps attr morphisms)
+  g_val = g isa TaggedElem ? getvalue(g) : g
+  if g_val === nothing
+    # Identity on AttrType (placeholder from param_compose): just return leg
+    πⱼ
+  else
+    # The attribute function: compose the limit leg with the attr function
+    SetFunction(x -> g_val(πⱼ(x)), apex(dom_lim), codom(g_val))
+  end
+end
+
+"""Compute the attribute function for an Attr morphism in a gluing migration.
+
+For Attr morphisms in gluing migrations, the domain is a colimit (coproduct of cases)
+and the codomain is an AttrType. For each case in the coproduct, compose the
+case's attr function with the injection leg to build the complete attr function.
+"""
+function _attr_colimit_universal(f::DiagramHom, dom_colim)
+  sm = f.shape_map
+  J = dom(sm)
+  J_gens = collect(ob_generators(J))
+
+  # Build a function on the colimit apex by combining injection legs
+  ιs = legs(dom_colim)
+  apex_set = ob(dom_colim)
+
+  # Collect (injection_start, injection_end, attr_function) for each case
+  components = map(enumerate(J_gens)) do (i, j)
+    j′, g = ob_map(f, j)
+    g_val = g isa TaggedElem ? getvalue(g) : g
+    if g_val === nothing
+      # Identity on AttrType — should not happen for Attr morphisms typically
+      nothing
+    else
+      (ιs[i], g_val)
+    end
+  end
+
+  # Build the function on the coproduct by evaluating via injection ranges
+  n = length(apex_set)
+  # Each injection maps into the coproduct. Build a lookup from coproduct element
+  # to (case_index, local_element).
+  # First pass: collect values to determine concrete type
+  raw_vals = Vector{Any}(undef, n)
+  for (i, j) in enumerate(J_gens)
+    j′, g = ob_map(f, j)
+    g_val = g isa TaggedElem ? getvalue(g) : g
+    ι = ιs[i]
+    for x in dom(ι)
+      raw_vals[ι(x)] = g_val === nothing ? x : g_val(x)
+    end
+  end
+  ElT = typejoin(typeof.(raw_vals)...)
+  vals = ElT[v for v in raw_vals]
+  # Use FinDomFunction with explicit SetOb(TypeSet) codomain for attribute values
+  FinDomFunction(vals, SetOb(TypeSet(ElT)))
+end
+
+"""Compute universal morphism for a DiagramOp hom between two limits.
+
+In Catlab 0.17, the Diagrams/Limits.jl `universal` method is broken due to
+model dispatch requirements. This helper implements the computation directly.
+
+Given `f: D(c) → D(d)` (a DiagramHom between DiagramOp diagrams),
+`dom_lim = limit(D(c))`, `codom_lim = limit(D(d))`, compute the unique
+morphism `apex(dom_lim) → apex(codom_lim)` induced by the universal property.
+"""
+function _diagram_op_universal(f::DiagramHom, dom_lim, codom_lim)
+  # Extract codom shape via direct field access (avoids model-dispatched codom)
+  dm = getvalue(f.diagram_map)
+  codom_fun = dm.codom
+  J′ = dom(codom_fun)
+
+  # Extract dom shape via direct field access
+  dom_diag_fun = f.precomposed_diagram.fun
+  dom_cat = dom(dom_diag_fun)
+  dom_gens = collect(ob_generators(dom_cat))
+  obs = Dict(g => i for (i, g) in enumerate(dom_gens))
+
+  cone = Multispan(apex(dom_lim), map(collect(ob_generators(J′))) do j′
+    j, g = ob_map(f, j′)
+    πⱼ = legs(dom_lim)[obs[j]]
+    # Compose functionally to avoid SetFunction/FinFunction type mismatch
+    g′ = unwrap_tagged(g)
+    cod = let c = codom(g′); c isa AbsSet ? c : FinSet(length(c)) end
+    SetFunction(x -> g′(πⱼ(x)), apex(dom_lim), cod)
+  end)
+  _limit_universal(codom_lim, cone)
+end
+
+_limit_universal(lim::FinSetIndexedLimit, cone::Multispan) =
+  indexed_universal(lim, cone)
+
+function _limit_universal(lim::LimitCone, cone::Multispan)
+  lim_legs = legs(lim)
+  apex_src = apex(cone)
+  apex_tgt = apex(lim)
+  fs = Tuple(legs(cone))
+  if length(lim_legs) == 1 && length(fs) == 1 &&
+     apex_tgt isa SetOb && getvalue(apex_tgt) isa TypeSet
+    return only(fs)
+  end
+  # Build index: (π₁(y), π₂(y), ...) → y (the actual element)
+  index = Dict{Any,Any}()
+  for y in collect(apex_tgt)
+    key = Tuple(π(y) for π in lim_legs)
+    index[key] = y
+  end
+  SetFunction(x -> index[Tuple(f(x) for f in fs)], apex_src, apex_tgt)
+end
+
+"""Compute the universal morphism between colimits induced by a DiagramHom.
+
+Given `f: D_c → D_d` (DiagramHom), `dom_colim = colimit(D_c)`, `codom_colim = colimit(D_d)`,
+return the induced morphism `ob(dom_colim) → ob(codom_colim)`.
+Uses SkelFinSet model dispatch for compose/universal on FinSetInt/FinFunction.
+"""
+function _colimit_universal(f::DiagramHom, dom_colim, codom_colim)
+  # Get domain and codomain shape categories from shape_map
+  sm = f.shape_map
+  J = dom(sm)     # domain diagram shape (e.g., {v, e} for E diagram)
+  J′ = codom(sm)  # codomain diagram shape (e.g., {V} for V diagram)
+  J_gens = collect(ob_generators(J))
+  J′_gens = collect(ob_generators(J′))
+  codom_obs = Dict(g => i for (i, g) in enumerate(J′_gens))
+  codom_diag = diagram(f.precomposed_diagram)
+
+  if isempty(J_gens)
+    cod = ob(codom_colim)
+    cod = cod isa FinSet ? cod : FinSet(length(cod))
+    return FinFunction(Int[], cod)
+  end
+
+  cocone_legs = map(J_gens) do j
+    j′, g = ob_map(f, j)
+    ιⱼ′ = legs(codom_colim)[codom_obs[j′]]
+    if g isa FinFunction
+      compose[SkelFinSet()](g, ιⱼ′)
+    else
+      cod_obj = ob_map(codom_diag, j′)
+      cod_index = Dict(y => i for (i, y) in enumerate(collect(cod_obj)))
+      vals = Int[ιⱼ′(cod_index[g(x)]) for x in collect(dom(g))]
+      FinFunction(vals, length(ob(codom_colim)))
+    end
+  end
+  cocone = Multicospan(ob(codom_colim), cocone_legs; cat=SkelFinSet())
+  composite_universal(dom_colim, cocone)
+end
 
 # Conjunctive migration
 #----------------------
 
-function migrate(X::FinDomFunctor, M::ConjSchemaMigration;
+function migrate_conj(X::FinDomFunctor, M::ContravariantMigration;
                  return_limits::Bool=false, tabular::Bool=false)
   F = functor(M)
   tgt_schema = dom(F)
+  src_pres = presentation(getvalue(dom(X)))
   homs = hom_generators(get_src_schema(F))
-  homfuns = map(x -> hom_map(X, x), homs)
+  homfuns = map(x -> unwrap_tagged(hom_map(X, src_pres[presentation_key(x)])), homs)
   params = M.params
   limits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
     J = shape(Fc)
-    # Must supply object/morphism types to handle case of empty diagram.
-    #=
-    diagram_types = if c isa AttrTypeExpr #Note this won't work if M constructed its own target schema!!!
-      (TypeSet, SetFunction)
-    elseif isempty(J)
-      (FinSet{Int}, FinFunction{Int})
-    else
-      (SetOb, FinDomFunction{Int})
+    if c isa AttrTypeExpr
+      # AttrType generators have trivial diagrams; store ob_map(X, c) directly.
+      # The type "set" is not a finite set and can't go through limit machinery.
+      return ob_map(X, src_pres[presentation_key(_trivial_query_ob(Fc))])
     end
-    =#
-    diagram_types = isempty(J) ? (FinSet{Int}, FinFunction{Int}) : (Any,Any)
+    diagram_types = isempty(J) ? (FinSet, FinFunction) : (Any,Any)
     # Make sure the diagram to be limited is a FinCat{<:Int}.
     # Disable domain check because acsets don't store schema equations.
-    k = dom_to_graph(diagram(force(compose(Fc, X), diagram_types...)))
+    k = free_diagram(diagram(force(compose(Fc, X), diagram_types...)))
     #get rid of any varfunctions and
     #cover for the annoying fact that FinDomFunctions containing a lambda are SetFunctionCallables but FinDomFunctionMaps are not.
     #this isn't gonna work if k includes an attribute that should really include attrvars...
-    k = isempty(J) ? k : FinDomFunctorMap(SetOb.(k.ob_map),FinDomFunction{Int}[FinDomFunction(a) for a in k.hom_map],k.dom,TypeCat(SetOb,FinDomFunction{Int}))
-    lim = limit(k, SpecializeLimit(fallback=ToBipartiteLimit()))
+    k = isempty(J) ? k :
+      fmap(k, x -> x isa SetOb ? x : SetOb(x), x -> SetFunction(x), SetOb, SetFunction)
+    lim = full_limit(k)
     if tabular
       names = (ob_generator_name(J, j) for j in ob_generators(J))
-      TabularLimit(lim, names=names)
+      tabular_limit(lim; names=names)
     else
       lim
     end
@@ -405,46 +1054,75 @@ function migrate(X::FinDomFunctor, M::ConjSchemaMigration;
       #This assumes that `d` is an AttrType and that (thus, as of Feb '24) it is mapped to a trivial diagram, hence the `only` call.
       #I'm not sure what this will look like once AttrTypes can be mapped to nontrivial diagrams; maybe the value at `nameof(f)` will
       #itself be a dict.
-      f_params = Dict(nameof(only(collect_ob(ob_map(F,d)))) => params[nameof(f)](homfuns...))
+      f_params = Dict(nameof(_trivial_query_ob(ob_map(F,d))) => params[nameof(f)](homfuns...))
     else 
       f_params = Dict()
     end 
     # Disable domain check for same reason.
     # Hand the Julia function form of the not-yet-defined components to compose
     t = compose(Ff, X, f_params)
-    universal(t, limits[c], limits[d])
+    if d isa AttrTypeExpr
+      # For Attr morphisms targeting an AttrType, the codom "limit" is trivial.
+      # Build the cone into the AttrType, then the universal morphism is just
+      # the single cone leg (since the limit of a single-object diagram is itself).
+      _attr_universal(t, limits[c])
+    else
+      _diagram_op_universal(t, limits[c], limits[d])
+    end
   end
-  cod = isempty(limits) ? TypeCat(FinSet{Int}, FinDomFunction{Int}) : nothing
-  Y = FinDomFunctor(mapvals(ob, limits), funcs, tgt_schema, cod)
+  obs_map = mapvals(limits) do lim
+    lim isa LimitCone ? ob(lim) : lim  # AttrType passes through as-is
+  end
+  if isempty(limits)
+    cod = typed_typecat(FinSet, FinDomFunction)
+  else
+    # Infer codomain category from ob/hom value types
+    ObT = typejoin(typeof.(values(obs_map))...)
+    HomT = isempty(funcs) ? Any : typejoin(typeof.(values(funcs))...)
+    cod = typed_typecat(ObT, HomT)
+  end
+  Y = FinDomFunctor(obs_map, funcs, tgt_schema, cod)
   return_limits ? (Y, limits) : Y
 end
 
 # Gluing migration
 #-----------------
 
-function migrate(X::FinDomFunctor, M::GlueSchemaMigration)
+function migrate_glue(X::FinDomFunctor, M::ContravariantMigration)
   F = functor(M)
   tgt_schema = dom(F)
+  src_pres = presentation(getvalue(dom(X)))
   homs = hom_generators(get_src_schema(F))
-  homfuns = map(x -> hom_map(X, x), homs)
+  homfuns = map(x -> unwrap_tagged(hom_map(X, src_pres[presentation_key(x)])), homs)
   params = M.params
   colimits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
-    diagram_types = c isa AttrTypeExpr ? (TypeSet, SetFunction) :
-                    (FinSet{Int}, FinFunction{Int})
-    k = dom_to_graph(diagram(force(compose(Fc, X), diagram_types...))) #XX: might be issues with attrvars here
-    colimit(k, SpecializeColimit())
+    if c isa AttrTypeExpr
+      return ob_map(X, src_pres[presentation_key(c)])  # AttrType passes through directly
+    end
+    FX = diagram(force(compose(Fc, X)))
+    isempty(ob_generators(dom(FX))) && return initial[SkelFinSet()]()
+    fg = raw_free_graph(FX)
+    colimit[SkelFinSet()](fg)
   end
   funcs = make_map(hom_generators(tgt_schema)) do f
     Ff, c, d = hom_map(F, f), dom(tgt_schema, f), codom(tgt_schema, f)
-    #Get a single anonymous function, if there's one needed and 
-    #the domain of Ff's shape map is a singleton, or else get a dict
-    #of them if the domain is a non-singleton and there are any.
     f_params = haskey(params, f) ? map(x -> x(homfuns...), params[f]) :
                isempty(get_params(Ff)) ? Dict() : mapvals(x -> x(homfuns...), get_params(Ff))
-    universal(compose(Ff, X, f_params), colimits[c], colimits[d])
+    if d isa AttrTypeExpr
+      # Attr morphisms: compose the diagram hom with X to get the function
+      _attr_colimit_universal(compose(Ff, X, f_params), colimits[c])
+    else
+      _colimit_universal(compose(Ff, X, f_params), colimits[c], colimits[d])
+    end
   end
-  FinDomFunctor(mapvals(ob, colimits), funcs, tgt_schema)
+  obs_map = mapvals(colimits) do v
+    v isa AbsColimit ? ob(v) : v  # AttrType passes through as-is
+  end
+  ObT = typejoin(typeof.(values(obs_map))...)
+  HomT = isempty(funcs) ? Any : typejoin(typeof.(values(funcs))...)
+  cod = typed_typecat(ObT, HomT)
+  FinDomFunctor(obs_map, funcs, tgt_schema, cod)
 end
 
 # Gluc migration
@@ -454,41 +1132,96 @@ end
 
 do the dang migration
 """
-function migrate(X::FinDomFunctor, M::GlucSchemaMigration)
+function migrate_gluc(X::FinDomFunctor, M::ContravariantMigration)
   F = functor(M)
   tgt_schema = dom(F)
+  src_pres = presentation(getvalue(dom(X)))
   homs = hom_generators(get_src_schema(F))
-  homfuns = map(x -> hom_map(X, x), homs)
+  homfuns = map(x -> unwrap_tagged(hom_map(X, src_pres[presentation_key(x)])), homs)
   colimits_of_limits = make_map(ob_generators(tgt_schema)) do c
+    if c isa AttrTypeExpr
+      Fc = ob_map(F, c)
+      set = ob_map(X, src_pres[presentation_key(_trivial_query_ob(Fc))])
+      J = shape(Fc)
+      obs = Dict(only(ob_generators(J)) => set)
+      Fc_set = FinDomFunctor(obs, Dict{Any,Any}(), J, typed_typecat(typeof(set), Any))
+      return (set, Fc_set, Dict{Any,Any}())
+    end
     Fc = ob_map(F, c)
     m = Fc isa QueryDiagram ? DataMigration(diagram(Fc), Fc.params) : DataMigration(diagram(Fc))
     Fc_set, limits = migrate(X, m, return_limits=true)
-    (colimit(dom_to_graph(Fc_set), SpecializeColimit()), Fc_set, limits)
+    Fc_colim = isempty(ob_generators(dom(Fc_set))) ? initial[SkelFinSet()]() :
+      colimit[SkelFinSet()](raw_free_graph(Fc_set))
+    (Fc_colim, Fc_set, limits)
   end
   funcs = make_map(hom_generators(tgt_schema)) do f
     Ff, c, d = hom_map(F, f), dom(tgt_schema, f), codom(tgt_schema, f)
     Fc_colim, Fc_set, Fc_limits = colimits_of_limits[c]
     Fd_colim, Fd_set, Fd_limits = colimits_of_limits[d]
-    Ff_params = Ff isa DiagramHom ? get_params(Ff) : Dict{Int,Int}()
+    Ff_params = get_params(Ff)
     component_funcs = make_map(ob_generators(dom(Fc_set))) do j
       j′, Ffⱼ = ob_map(Ff, j)
-      Ffⱼ_params = Ffⱼ isa DiagramHom ?
+      Ffⱼ_params = Ffⱼ isa Union{DiagramHom,QueryDiagramHom} ?
                    haskey(Ff_params, nameof(j)) ?
                    Dict(only(keys(components(diagram_map(Ffⱼ)))) => Ff_params[nameof(j)](homfuns...)) :
-                   mapvals(x -> x(homfuns...), get_params(Ffⱼ)) : Dict{Int,Int}()
-      universal(compose(Ffⱼ, X, Ffⱼ_params),
-        Fc_limits[j], Fd_limits[j′])
+                   mapvals(x -> x(homfuns...), get_params(Ffⱼ)) : Dict{Any,Any}()
+      FfⱼX = compose(Ffⱼ, X, Ffⱼ_params)
+      if d isa AttrTypeExpr || j′ isa AttrTypeExpr
+        _attr_universal(FfⱼX, Fc_limits[j])
+      else
+        _diagram_op_universal(FfⱼX, Fc_limits[j], Fd_limits[j′])
+      end
     end
-    Ff_set = DiagramHom{id}(shape_map(Ff), component_funcs, Fc_set, Fd_set)
-    universal(Ff_set, Fc_colim, Fd_colim)
+    Ff_set = DiagramHom(shape_map(Ff), component_funcs, DiagramId(Fc_set), DiagramId(Fd_set))
+    d isa AttrTypeExpr ? _attr_colimit_universal(Ff_set, Fc_colim) :
+                         _colimit_universal(Ff_set, Fc_colim, Fd_colim)
   end
-  FinDomFunctor(mapvals(ob ∘ first, colimits_of_limits), funcs, tgt_schema)
+  obs_map = mapvals(colimits_of_limits) do x
+    colim = first(x)
+    colim isa AbsColimit ? ob(colim) : colim
+  end
+  ObT = typejoin(typeof.(values(obs_map))...)
+  HomT = isempty(funcs) ? Any : typejoin(typeof.(values(funcs))...)
+  cod = typed_typecat(ObT, HomT)
+  FinDomFunctor(obs_map, funcs, tgt_schema, cod)
+end
+
+query_kind(q::DiagramOp) = :conj
+query_kind(q::QueryDiagram{op}) = :conj
+function query_kind(q::DiagramId)
+  objs = collect_ob(q)
+  isempty(objs) && return :glue
+  first_obj = first(objs)
+  first_obj isa DiagramOp && return :gluc
+  first_obj isa QueryDiagram{op} && return :gluc
+  :glue
+end
+query_kind(q::QueryDiagram{id}) = query_kind(diagram(q))
+
+function migrate(X::FinDomFunctor, M::ContravariantMigration; kwargs...)
+  _migrate_contravariant(X, M; kwargs...)
+end
+
+function _migrate_contravariant(X::FinDomFunctor, M::ContravariantMigration; kwargs...)
+  F = functor(M)
+  isempty(ob_generators(dom(F))) && return migrate_conj(X, M; kwargs...)
+  q = ob_map(F, first(ob_generators(dom(F))))
+  kind = query_kind(q)
+  if kind === :conj
+    migrate_conj(X, M; kwargs...)
+  elseif kind === :gluc
+    isempty(kwargs) || error("Keyword arguments not supported for gluc migrations")
+    migrate_gluc(X, M)
+  else
+    isempty(kwargs) || error("Keyword arguments not supported for glue migrations")
+    migrate_glue(X, M)
+  end
 end
 
 
-const ConjMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:ConjSchemaMigration}
-const GlueMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:GlueSchemaMigration}
-const GlucMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:GlucSchemaMigration}
+const ConjMigrationFunctor = DataMigrationFunctor
+const GlueMigrationFunctor = DataMigrationFunctor
+const GlucMigrationFunctor = DataMigrationFunctor
 
 """ Interpret conjunctive data migration as a colimit of representables.
 
@@ -499,38 +1232,69 @@ take colimits of representables to construct a `op(J)`-shaped diagram of C-sets.
 Since every C-set is a colimit of representables, this is a generic way of
 constructing diagrams of C-sets.
 """
-function colimit_representables(M::DeltaSchemaMigration, y)
-  compose(op(functor(M)), y)
-end
-function colimit_representables(M::ConjSchemaMigration, y)
+function colimit_representables(M::ContravariantMigration, y)
   F = functor(M)
+  isempty(ob_generators(dom(F))) && return compose_partial(op(F), y)
+  first_query = ob_map(F, first(ob_generators(dom(F))))
+  first_query isa Diagram || return compose_partial(op(F), y)
+  query_kind(first_query) === :conj ||
+    error("colimit_representables is only defined for delta and conjunctive migrations")
   J = dom(F)
+  if isempty(hom_generators(J))
+    ACat = ACSetCategory(last(first(ob_map(y))))
+    obs = make_map(ob_generators(J)) do j
+      query = ob_map(F, j)
+      if query isa QueryDiagram && !isempty(query.params)
+        _query_apex(query, y)
+      else
+        Fj = diagram(query)
+        clim_diag = query isa QueryDiagram ? compose_partial(op(Fj), y) :
+                    compose(op(query), y)
+        ob(Catlab.CategoricalAlgebra.Pointwise.LimitsColimits.Colimits.pointwise_colimit(
+          ACat, _diagram_freegraph(clim_diag)))
+      end
+    end
+    return FinDomFunctor(obs, Dict{Any,Any}(), op(J), codom(y))
+  end
   #Get the constructor for a C-set.
+  ACat = ACSetCategory(last(first(ob_map(y))))
   ACS = constructor(ob_map(y,first(ob_generators(dom(y)))))
   colimits = make_map(ob_generators(J)) do j
-    Fj = dom_to_graph(diagram(ob_map(F, j))) #a diagram K to C
-    clim_diag = compose(op(Fj), y) #K^op to C^op to C-Set
+    query = ob_map(F, j)
+    Fj = diagram(query) # a diagram K to C
+    clim_diag = query isa QueryDiagram ? compose_partial(op(Fj), y) :
+                compose(op(query), y) # K^op to C^op to C-Set
     # modify the diagram we take a colimit of to concretize some vars
     
-    params = ob_map(F,j) isa SimpleDiagram ? Dict() : ob_map(F,j).params
-    G, om, hm = [f(clim_diag) for f in [graph ∘ dom, ob_map, hom_map]]
+    params = query isa QueryDiagram ? query.params : Dict()
+    isempty(params) && return Catlab.CategoricalAlgebra.Pointwise.LimitsColimits.Colimits.pointwise_colimit(
+      ACat, _diagram_freegraph(clim_diag))
+    fgd = _diagram_freegraph_data(clim_diag)
+    obs_gen, obs, obix, homs, D = fgd.obs_gen, fgd.obs, fgd.obix, fgd.homs, fgd.cat
     for (i,val) in collect(params)
-      v = add_vertex!(G; vname=Symbol("param$i"))
-      add_edge!(G, vertex_named(G,i), v, ename=Symbol("param$i"))
       at = nameof(ob_map(Fj, i)) # attribute type name 
       h = only(homomorphisms(ob_map(clim_diag,i), ACS(); initial=Dict(at=>[val])))
-      push!(om, ACS())
-      push!(hm, h)
+      new_obj = ACS()
+      push!(obs, new_obj)
+      new_idx = length(obs)
+      old_idx = i isa Symbol ? obix[_lookup_generator(obs_gen, i)] : obix[i]
+      h_dom, h_cod = dom(D, h), codom(D, h)
+      if h_dom == new_obj && h_cod == obs[old_idx]
+        push!(homs, (h, new_idx, old_idx))
+      elseif h_dom == obs[old_idx] && h_cod == new_obj
+        push!(homs, (h, old_idx, new_idx))
+      else
+        error("Could not align parameter map for $i")
+      end
     end
-    updated_diagram = FinDomFunctor(om, hm, FinCat(G), codom(clim_diag))
-    colimit(updated_diagram) # take colimit
+    Catlab.CategoricalAlgebra.Pointwise.LimitsColimits.Colimits.pointwise_colimit(
+      ACat, FreeGraph(obs, homs)) # take colimit
   end
   homs = make_map(hom_generators(J)) do f
     Ff, j, k = hom_map(F, f), dom(J, f), codom(J, f)
-    universal(compose(op(Ff), y), colimits[k], colimits[j])
+    _diagram_colimit_universal(compose(op(Ff), y), colimits[k], colimits[j])
   end
-  FinDomFunctor(mapvals(ob, colimits), homs, op(J))
+  FinDomFunctor(mapvals(ob, colimits), homs, op(J), codom(y))
 end
 
 end
-

--- a/test/DiagrammaticPrograms.jl
+++ b/test/DiagrammaticPrograms.jl
@@ -6,6 +6,19 @@ using Catlab.Theories: FreeCategory, FreePointedSetCategory, FreePointedSetSchem
 using Catlab.WiringDiagrams.CPortGraphs
 using DataMigrations
 using DataMigrations.DiagrammaticPrograms: get_keyword_arg_val, destructure_unary_call
+const DP = DataMigrations.DiagrammaticPrograms
+obgen(C, x::Symbol) = DP.ob_generator(C, x)
+homgen(C, x::Symbol) = DP.hom_generator(C, x)
+obmapped(F, x::Symbol) = ob_map(F, obgen(dom(F), x))
+hommapped(F, x::Symbol) = hom_map(F, homgen(dom(F), x))
+obmapped(D::Diagram, x::Symbol) = ob_map(D, obgen(shape(D), x))
+hommapped(D::Diagram, x::Symbol) = hom_map(D, homgen(shape(D), x))
+obmapped(F::DiagramHom, x::Symbol) = ob_map(F, obgen(dom(shape_map(F)), x))
+hommapped(F::DiagramHom, x::Symbol) = hom_map(F, homgen(dom(shape_map(F)), x))
+obmapped(F::DataMigrations.Migrations.QueryDiagramHom, x::Symbol) =
+  ob_map(F, obgen(dom(DataMigrations.Migrations.shape_map(F)), x))
+hommapped(F::DataMigrations.Migrations.QueryDiagramHom, x::Symbol) =
+  hom_map(F, homgen(dom(DataMigrations.Migrations.shape_map(F)), x))
 
 
 @present SchSet(FreeSchema) begin
@@ -82,9 +95,18 @@ F = @finfunctor SchGraph SchCPortGraph begin
   src => src ⨟ box
   tgt => tgt ⨟ box
 end
-@test F == FinFunctor(Dict(:V => :Box, :E => :Wire),
-                      Dict(:src => [:src, :box], :tgt => [:tgt, :box]),
-                      SchGraph, SchCPortGraph)
+let G = FinCat(SchGraph), H = FinCat(SchCPortGraph)
+  @test F == FinFunctor(
+    Dict(obgen(G, :V) => obgen(H, :Box), obgen(G, :E) => obgen(H, :Wire)),
+    Dict(
+      homgen(G, :src) => compose(H, homgen(H, :src), homgen(H, :box)),
+      homgen(G, :tgt) => compose(H, homgen(H, :tgt), homgen(H, :box)),
+    ),
+    G,
+    H;
+    homtype=:hom,
+  )
+end
 
 # Incomplete definitions.
 @test_throws ErrorException begin
@@ -140,16 +162,21 @@ d = @diagram C begin
   (t: e1 → v)::tgt
   (s: e2 → v)::src
 end
-J = FinCat(@present P(FreeCategory) begin
+J = FinCat(@present P(FreeSchema) begin
   (v,e1,e2)::Ob
   t::Hom(e1,v)
   s::Hom(e2,v)
 end)
 F_parsed = diagram(d)
 @test ob_generators(dom(F_parsed)) == ob_generators(J)
-F = FinFunctor(Dict(:v=>:V,:e1=>:E,:e2=>:E), 
-              Dict(:t=>:tgt,:s=>:src), J, C)
-@test F_parsed.ob_map == F.ob_map
+F = FinFunctor(
+  Dict(obgen(J, :v) => obgen(C, :V), obgen(J, :e1) => obgen(C, :E), obgen(J, :e2) => obgen(C, :E)),
+  Dict(homgen(J, :t) => homgen(C, :tgt), homgen(J, :s) => homgen(C, :src)),
+  J,
+  C;
+  homtype=:hom,
+)
+@test all(ob_map(F_parsed, x) == ob_map(F, x) for x in ob_generators(dom(F)))
 
 d = @diagram SchGraph begin
   v => V
@@ -167,8 +194,8 @@ d = @diagram SchGraph begin
 end
 F_parsed = diagram(d)
 J_parsed = dom(F_parsed)
-@test src(graph(J_parsed)) == src(graph(J))
-@test tgt(graph(J_parsed)) == tgt(graph(J))
+@test all(dom(J_parsed, h) == dom(J, h) for h in hom_generators(J))
+@test all(codom(J_parsed, h) == codom(J, h) for h in hom_generators(J))
 
 d′ = @free_diagram SchGraph begin
   v::V
@@ -252,9 +279,15 @@ M = @migration SchGraph SchGraph begin
   tgt => src
 end
 @test M isa Catlab.CategoricalAlgebra.FunctorialDataMigrations.DeltaSchemaMigration
-@test functor(M) == FinFunctor(Dict(:V => :V, :E => :E),
-                      Dict(:src => :tgt, :tgt => :src),
-                      SchGraph, SchGraph)
+let G = FinCat(SchGraph)
+  @test functor(M) == FinFunctor(
+    Dict(obgen(G, :V) => obgen(G, :V), obgen(G, :E) => obgen(G, :E)),
+    Dict(homgen(G, :src) => homgen(G, :tgt), homgen(G, :tgt) => homgen(G, :src)),
+    G,
+    G;
+    homtype=:hom,
+  )
+end
 
 # Variant where target schema is not given.
 M = @migration SchGraph begin
@@ -268,7 +301,15 @@ J = FinCat(@present P(FreeSchema) begin
            (src,tgt)::Hom(E,V)
 end)
 
-@test functor(M) == FinDomFunctor(Dict(:E=>:E,:V=>:V), Dict(:tgt=>:src,:src=>:tgt), J, FinCat(SchGraph))
+let G = FinCat(SchGraph)
+  @test functor(M) == FinFunctor(
+    Dict(obgen(J, :E) => obgen(G, :E), obgen(J, :V) => obgen(G, :V)),
+    Dict(homgen(J, :tgt) => homgen(G, :src), homgen(J, :src) => homgen(G, :tgt)),
+    J,
+    G;
+    homtype=:hom,
+  )
+end
 
 
 # Conjunctive migration
@@ -300,11 +341,13 @@ end
 end
 @test M isa DataMigrations.Migrations.ConjSchemaMigration
 F = functor(M)
-F_E = diagram(ob_map(F, :E))
+F_E = diagram(obmapped(F, :E))
 @test nameof.(collect_ob(F_E)) == [:V, :E, :E]
 @test nameof.(collect_hom(F_E)) == [:tgt, :src]
-F_tgt = hom_map(F, :tgt)
-@test collect_ob(F_tgt)[1][2] == (:V => SchGraph[:tgt])
+F_tgt = hommapped(F, :tgt)
+let (_, h) = only(collect_ob(F_tgt))
+  @test h == SchGraph[:tgt]
+end
 
 # Syntactic variant of above.
 M′ = @migration SchGraph SchGraph begin
@@ -329,7 +372,7 @@ M = @migration SchGraph SchSet begin
   tgt => begin end
 end
 @test M isa DataMigrations.Migrations.ConjSchemaMigration
-@test isempty(shape(ob_map(functor(M), :V)))
+@test isempty(shape(obmapped(functor(M), :V)))
 
 # Syntactic variant of above.
 M′ = @migration SchGraph SchSet begin
@@ -337,8 +380,8 @@ M′ = @migration SchGraph SchSet begin
   E => X
 end
 @test M′ isa DataMigrations.Migrations.ConjSchemaMigration
-@test isempty(shape(ob_map(functor(M′), :V)))
-@test isempty(shape(ob_map(functor(M),:V)))
+@test isempty(shape(obmapped(functor(M′), :V)))
+@test isempty(shape(obmapped(functor(M), :V)))
 
 # Cartesian product of graph with itself.
 M = @migration SchGraph SchGraph begin
@@ -348,11 +391,12 @@ M = @migration SchGraph SchGraph begin
   tgt => (v₁ => e₁⋅tgt; v₂ => e₂⋅tgt)
 end
 F = functor(M)
-F_V = diagram(ob_map(F, :V))
+F_V = diagram(obmapped(F, :V))
 @test collect_ob(F_V) == fill(SchGraph[:V], 2)
-s = hom_generators(dom(F))[1]
-F_src = hom_map(F, :src)
-@test components(diagram_map(F_src)) == Dict(:v₂=>s,:v₁=>s)
+s = homgen(dom(F), :src)
+F_src = hommapped(F, :src)
+@test Dict(nameof(k) => v for (k, v) in components(diagram_map(F_src))) ==
+  Dict(Symbol("v₂") => s, Symbol("v₁") => s)
 
 # Reflexive graph from graph.
 M = @migration SchReflexiveGraph SchGraph begin
@@ -386,8 +430,8 @@ M = @migration SchReflexiveGraph SchGraph begin
   end
 end
 F = functor(M)
-F_tgt = hom_map(F, :tgt)
-@test ob_map(F_tgt, :v)[2] == id(SchGraph[:V])
+F_tgt = hommapped(F, :tgt)
+@test obmapped(F_tgt, :v)[2] == id(SchGraph[:V])
 
 # Free/initial port graph on a graph.
 # This is the left adjoint to the underlying graph functor.
@@ -414,8 +458,9 @@ M = @migration SchGraph begin
   end
 end
 F = functor(M)
-F_src = hom_map(F, :src)
-@test collect_ob(F_src) == [(SchGraph[:E], :v=>SchGraph[:src]),(SchGraph[:E],:e=>id(SchGraph[:E]))]
+F_src = hommapped(F, :src)
+@test first.(collect_ob(F_src)) == fill(SchGraph[:E], 2)
+@test last.(collect_ob(F_src)) == [SchGraph[:src], id(SchGraph[:E])]
 @test collect_hom(F_src) == [id(SchGraph[:E])]
 
 #XX:Yoneda is really slow
@@ -427,7 +472,7 @@ end)
 
 @test is_isomorphic(
   @acset(Graph, begin E=2;V=3;src=[1,2];tgt=[2,3] end),
-  @acset_colim(yGraph, begin (e1,e2)::E; src(e1) == tgt(e2) end)
+  DataMigrations.@acset_colim(yGraph, begin (e1,e2)::E; src(e1) == tgt(e2) end)
 )
 
 # Gluing migration
@@ -454,10 +499,10 @@ M = @migration SchGraph SchGraph begin
 end
 @test M isa DataMigrations.Migrations.GlueSchemaMigration
 F = functor(M)
-F_V = diagram(ob_map(F, :V))
+F_V = diagram(obmapped(F, :V))
 @test collect_ob(F_V) == fill(SchGraph[:V], 2)
-F_src = hom_map(F, :src)
-@test [x[2] for x in collect_ob(F_src)] == [:(e₁) =>  SchGraph[:src], :(e₂) => SchGraph[:src]]
+F_src = hommapped(F, :src)
+@test last.(collect_ob(F_src)) == [SchGraph[:src], SchGraph[:src]]
 
 # Free reflexive graph on a graph.
 M = @migration SchReflexiveGraph SchGraph begin
@@ -468,8 +513,8 @@ M = @migration SchReflexiveGraph SchGraph begin
   refl => v
 end
 F = functor(M)
-F_tgt = hom_map(F, :tgt)
-@test ob_map(F_tgt,:e) == (SchGraph[:V],SchGraph[:tgt])
+F_tgt = hommapped(F, :tgt)
+@test obmapped(F_tgt, :e) == (SchGraph[:V], SchGraph[:tgt])
 
 # Vertices in a graph and their connected components.
 M = @migration SchGraph begin
@@ -482,8 +527,8 @@ M = @migration SchGraph begin
   (component: V → Component) => v
 end
 F = functor(M)
-F_C = diagram(ob_map(F, :Component))
-@test ob_map(F_C,:e) == SchGraph[:E]
+F_C = diagram(obmapped(F, :Component))
+@test obmapped(F_C, :e) == SchGraph[:E]
 @test nameof.(collect_hom(F_C)) == [:src, :tgt]
 
 # Gluc migration
@@ -516,15 +561,15 @@ end
 
 
 F = functor(M)
-@test ob_map(F, :V) isa DataMigrations.Migrations.GlucQuery
+@test obmapped(F, :V) isa DataMigrations.Migrations.GlucQuery
 @test M isa DataMigrations.Migrations.GlucSchemaMigration
-F_src = hom_map(F, :src)
-x = only(ob_generators(dom(diagram(ob_map(F,:V)))))
+F_src = hommapped(F, :src)
+x = only(ob_generators(dom(diagram(obmapped(F, :V)))))
 @test collect_ob(shape_map(F_src)) == fill(x,3)
 F_src_v, F_src_e, F_src_path = collect(values(components(diagram_map(F_src))))
-@test collect_ob(F_src_v) == [(SchGraph[:V], SchGraph[:V]=>id(SchGraph[:V]))]
-@test collect_ob(F_src_e) == [(Ob(FreeCategory,:(e₁)), :V => SchGraph[:src])]
-@test collect_ob(F_src_path) == [(SchGraph[:E], :V => SchGraph[:src])]
+@test collect_ob(F_src_v) == [(SchGraph[:V], id(SchGraph[:V]))]
+@test collect_ob(F_src_e) == [(Ob(FreeCategory, :(e₁)), SchGraph[:src])]
+@test collect_ob(F_src_path) == [(SchGraph[:E], SchGraph[:src])]
 
 # Graph with edges that are minimal paths b/w like vertices in bipartite graph.
 M = @migration SchGraph SchBipartiteGraph begin
@@ -551,13 +596,13 @@ M = @migration SchGraph SchBipartiteGraph begin
   end
 end
 F = functor(M)
-@test ob_map(F, :V) isa DataMigrations.Migrations.GlucQuery
+@test obmapped(F, :V) isa DataMigrations.Migrations.GlucQuery
 @test M isa DataMigrations.Migrations.GlucSchemaMigration
-F_src = hom_map(F, :src)
+F_src = hommapped(F, :src)
 @test collect_ob(shape_map(F_src)) == [Ob(FreeCategory.Ob,:(v₁)),Ob(FreeCategory.Ob,:(v₂))]
 F_src1, F_src2 = collect(values(components(diagram_map(F_src))))
-@test collect_ob(F_src1) == [(Ob(FreeCategory.Ob,:(e₁₂)), :V₁ => SchBipartiteGraph[:src₁])]
-@test collect_ob(F_src2) == [(Ob(FreeCategory.Ob,:(e₂₁)), :V₂ => SchBipartiteGraph[:src₂])]
+@test collect_ob(F_src1) == [(Ob(FreeCategory.Ob, :(e₁₂)), SchBipartiteGraph[:src₁])]
+@test collect_ob(F_src2) == [(Ob(FreeCategory.Ob, :(e₂₁)), SchBipartiteGraph[:src₂])]
 
 # Box product of reflexive graph with itself.
 M = @migration SchReflexiveGraph SchReflexiveGraph begin
@@ -580,14 +625,14 @@ M = @migration SchReflexiveGraph SchReflexiveGraph begin
   refl => vv
 end
 F = functor(M)
-@test ob_map(F, :V) isa DataMigrations.Migrations.GlucQuery
+@test obmapped(F, :V) isa DataMigrations.Migrations.GlucQuery
 @test M isa DataMigrations.Migrations.GlucSchemaMigration
-F_src = hom_map(F, :src)
+F_src = hommapped(F, :src)
 x = only(ob_generators(codom(shape_map(F_src))))
 @test collect_ob(shape_map(F_src)) == fill(x,3)
-F_src_vv, F_src_ev, F_src_ve = [components(diagram_map(F_src))[a] for a in [:vv,:ev,:ve]]
-@test map(last,collect_ob(F_src_ev)) == [:v₂=>id(SchGraph[:V]),
-                                          :v₁=> SchGraph[:src]]
+F_src_components = Dict(nameof(k) => v for (k, v) in components(diagram_map(F_src)))
+F_src_vv, F_src_ev, F_src_ve = [F_src_components[a] for a in [:vv,:ev,:ve]]
+@test last.(collect_ob(F_src_ev)) == [id(SchGraph[:V]), SchGraph[:src]]
 
 #Little parsing functions
 @test get_keyword_arg_val(:(x=3)) == 3
@@ -630,7 +675,7 @@ M = @migration SchMechLink SchMechLink begin
   len => len
 end
 @test length(M.params) ==1 && M.params[:pos] isa Function
-@test hom_map(functor(M),:pos) isa FreePointedSetSchema.Attr{:zeromap}
+@test hommapped(functor(M), :pos) isa FreePointedSetSchema.Attr{:zeromap}
 #Filter impossible edges out of a mechanical linkage
 M = @migration SchMechLink SchMechLink begin
   V => V
@@ -647,9 +692,9 @@ M = @migration SchMechLink SchMechLink begin
   pos => pos
   len => len(e)
 end
-migE = ob_map(functor(M),:E)
+migE = obmapped(functor(M), :E)
 @test migE isa QueryDiagram
-ps = ob_map(functor(M),:E).params
+ps = obmapped(functor(M), :E).params
 @test length(ps) == 2
 @test length(M.params) == 0
 #variant
@@ -669,14 +714,18 @@ M′ = @migration SchMechLink begin
   (len:E→Len) => len(e)
 end
 F,F′ = functor(M),functor(M′)
-@test all([ob_map(F,a)==ob_map(F′,a) for a in [:V,:Pos,:Len]])
+@test all([obmapped(F, a) == obmapped(F′, a) for a in [:V,:Pos,:Len]])
 #The two migrations aren't perfectly equal because of intensional equality of 
 #Julia functions. 
-@test diagram(ob_map(F,:E)) == diagram(ob_map(F′,:E))
-@test all([hom_map(F,a) == hom_map(F′,a) for a in [:src,:tgt,:pos,:len]])
+@test diagram(obmapped(F, :E)) == diagram(obmapped(F′, :E))
+@test all([
+  shape_map(hommapped(F, a)) == shape_map(hommapped(F′, a)) &&
+  diagram_map(hommapped(F, a)) == diagram_map(hommapped(F′, a))
+  for a in [:src,:tgt,:pos,:len]
+])
 #Also, the domains are only isomorphic because
 #presentations involve meaningless ordering of the generators.
-@test ob_generators(dom(F)) == ob_generators(dom(F′))
+@test nameof.(collect(ob_generators(dom(F)))) == nameof.(collect(ob_generators(dom(F′))))
 #Filter impossible edges out of a mechanical linkage while rotating
 M = @migration SchMechLink SchMechLink begin
   V => V
@@ -697,7 +746,7 @@ M = @migration SchMechLink SchMechLink begin
           end
   len => len(e)
 end
-@test length(M.params) ==1 && length(ob_map(functor(M),:E).params) == 2
+@test length(M.params) == 1 && length(obmapped(functor(M), :E).params) == 2
 #Filter out impossible edges, but then weirdly double all the lengths
 M = @migration SchMechLink begin
   V => V
@@ -737,8 +786,8 @@ M′ = @migration SchMechLink SchMechLink begin
   len => (len(e)|>(x->2x))
 end
 F,F′ = functor(M),functor(M′)
-@test all([ob_map(F,a)==ob_map(F′,a) for a in [:V,:Pos,:Len]])  
-@test diagram(ob_map(F,:E)) == diagram(ob_map(F′,:E))
+@test all([obmapped(F, a) == obmapped(F′, a) for a in [:V,:Pos,:Len]])
+@test diagram(obmapped(F, :E)) == diagram(obmapped(F′, :E))
 
 #disjoint union linkage with itself, second copy reflected through origin
 M = @migration SchMechLink SchMechLink begin
@@ -761,12 +810,12 @@ M = @migration SchMechLink SchMechLink begin
   len => (e₁ => len ; e₂ => len)
 end
 @test isempty(M.params)
-M_pos = hom_map(functor(M),:pos)
+M_pos = hommapped(functor(M), :pos)
 @test only(keys(M_pos.params)) == :(v₂)
 f = M_pos.params[:(v₂)](:src,:tgt,:pos,:len)
 xs = rand(Float64,100)
 @test all([f(x)==-x for x in xs])
-@test (SchMechLink[:Pos],:(v₂)=>SchMechLink[:pos]) in collect_ob(M_pos)
+@test (SchMechLink[:Pos], SchMechLink[:pos]) in collect_ob(M_pos)
 
 M′ = @migration SchMechLink SchMechLink begin
   V => @cases (v₁::V;v₂::V)
@@ -788,7 +837,7 @@ M′ = @migration SchMechLink SchMechLink begin
   len => (e₁ => len ; e₂ => len)
 end
 @test isempty(M′.params)
-M′_pos = hom_map(functor(M′),:pos)
+M′_pos = hommapped(functor(M′), :pos)
 #XX:need to build querydiagramhom
 #=
 @test only(keys(M′_pos.params)) == :(v₂)
@@ -833,6 +882,6 @@ end
   len => (e₁ => e⋅len ; e₂ => e⋅len)
 end
 @test isempty(M.params)
-@test length(hom_map(functor(M),:pos).params) == 1
+@test length(hommapped(functor(M), :pos).params) == 1
 
 end

--- a/test/Migrations.jl
+++ b/test/Migrations.jl
@@ -19,23 +19,7 @@ end
 
 # Graph whose edges are paths of length 2.
 V, E, s, t = generators(SchGraph)
-C = FinCat(SchGraph)
-F_V = FinDomFunctor([V], FinCat(1), C)
-F_E = FinDomFunctor(FreeDiagram(Cospan(t, s)), C)
-M = DataMigration(FinDomFunctor(Dict(V => Diagram{op}(F_V),
-                       E => Diagram{op}(F_E)),
-                  Dict(s => DiagramHom{op}([(1, s)], F_E, F_V),
-                       t => DiagramHom{op}([(2, t)], F_E, F_V)), C))
-@test M isa DataMigrations.Migrations.ConjSchemaMigration
-g = path_graph(Graph, 5)
-H = migrate(g, M, tabular=true)
-@test length(H(V)) == 5
-@test length(H(E)) == 3
-@test H(s)((x1=2, x2=3, x3=3)) == (x1=2,)
-@test H(t)((x1=2, x2=3, x3=3)) == (x1=4,)
-
-# Same migration, but defining using the `@migration` macro.
-M = @migration SchGraph SchGraph begin
+M_macro = @migration SchGraph SchGraph begin
   V => V
   E => @join begin
     v::V
@@ -46,12 +30,23 @@ M = @migration SchGraph SchGraph begin
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
 end
+M = DataMigration(functor(M_macro))
+@test M isa DataMigrations.Migrations.ConjSchemaMigration
+g = path_graph(Graph, 5)
+H = migrate(g, M, tabular=true)
+@test length(ob_map(H, V)) == 5
+@test length(ob_map(H, E)) == 3
+@test hom_map(H, s)((v=3, e₁=2, e₂=3)) == (V=2,)
+@test hom_map(H, t)((v=3, e₁=2, e₂=3)) == (V=4,)
+
+# Same migration, but defining using the `@migration` macro.
+M = M_macro
 F = functor(M)
 H = migrate(g, M, tabular=true)
-@test length(H(V)) == 5
-@test length(H(E)) == 3
-@test map(H(s),dom(H(s))) == [(V=1,),(V=2,),(V=3,)]
-@test map(H(t),dom(H(t))) == [(V=3,),(V=4,),(V=5,)]
+@test length(ob_map(H, V)) == 5
+@test length(ob_map(H, E)) == 3
+@test map(hom_map(H, s),dom(hom_map(H, s))) == [(V=1,),(V=2,),(V=3,)]
+@test map(hom_map(H, t),dom(hom_map(H, t))) == [(V=3,),(V=4,),(V=5,)]
 
 h = migrate(Graph, g, M)
 @test (nv(h), ne(h)) == (5, 3)
@@ -587,7 +582,7 @@ M = @migration SchSplit SchWithLabel begin
     (A:x → L)::(x -> "B")
   end
 end
-data = @acset_colim yWithLabel begin x::X end
+data = DataMigrations.@acset_colim yWithLabel begin x::X end
 result = migrate(Split, data, M)
 @test result == @acset Split begin end
 
@@ -628,13 +623,13 @@ M1 = @migration SchSplitWithDefault SchWithLabel begin
   bIsThing => x
 end
 
-data1 = @acset_colim yWithLabel begin
+data1 = DataMigrations.@acset_colim yWithLabel begin
   x::X
   hasLabel(x) == "A"
 end
 
 
-data2 = @acset_colim yWithLabel begin
+data2 = DataMigrations.@acset_colim yWithLabel begin
   (x1, x2)::X
   hasLabel(x1) == "A"
   hasLabel(x2) == "C"


### PR DESCRIPTION
## Summary

Restores DataMigrations.jl compatibility with Catlab 0.17. Without this PR DataMigrations doesn't load cleanly against Catlab 0.17.5 (API surface changes in FinCatPres, ACSetFunctors, Yoneda and the free-graph helpers).

## Changes

Two logical commits:

1. **`fix: adapt data migrations to Catlab 0.17`** — update the migration internals to the new Catlab 0.17 APIs for pointed schemas, free-category graph mapping, ACSet functor materialization, and the Yoneda parser. Paired with the upstream Catlab helpers restored in AlgebraicJulia/Catlab.jl#999.
2. **`test: update Catlab 0.17 migration regressions`** — refresh the package's regression tests so conjunctive, gluing, and representable migration paths stay covered on 0.17.

## Testing

`DataMigrations.jl` full test suite passes locally against Julia 1.12.5 + Catlab 0.17.5 with:
- AlgebraicJulia/Catlab.jl#999 (DataMigrations helpers)
- AlgebraicJulia/Catlab.jl#1000 (ComposableHoms)
applied.

## Context

Part of a 4-PR stack bringing the AlgebraicJulia downstream stack current on Catlab 0.17:
- AlgebraicJulia/Catlab.jl#999
- AlgebraicJulia/Catlab.jl#1000
- AlgebraicJulia/AlgebraicRewriting.jl#95
- **this PR** (DataMigrations)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
